### PR TITLE
Remove duplicate date parser

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ import shutil
 import zipfile
 import pandas as pd
 import json  # NEW: for reading from secrets
+from datetime import datetime, timedelta
+import requests
 
 st.markdown(
     """
@@ -198,10 +200,7 @@ if st.button("🚀 Generate & Download All Reports"):
             shutil.rmtree(temp_dir)
             os.remove(zip_buffer.name)
 
-import streamlit as st
-from datetime import datetime, timedelta
-from docxtpl import DocxTemplate
-import requests
+
 
 def parse_any_date(datestr):
     for fmt in ("%d.%m.%Y", "%d/%m/%Y", "%Y-%m-%d"):
@@ -230,15 +229,6 @@ def generate_hf_summary(text, hf_token):
     except Exception:
         return "Summary not available. Please check your Hugging Face token or try again later."
 
-st.header("🗓️ Generate Weekly Electrical Consultant Report")
-
-def parse_any_date(datestr):
-    for fmt in ("%d.%m.%Y", "%d/%m/%Y", "%Y-%m-%d"):
-        try:
-            return datetime.strptime(datestr, fmt).date()
-        except ValueError:
-            continue
-    raise ValueError(f"Unknown date format: {datestr}")
 
 st.header("🗓️ Generate Weekly Electrical Consultant Report")
 


### PR DESCRIPTION
## Summary
- clean up duplicate `parse_any_date` function definition
- consolidate imports at the top of the file
- keep a single header before weekly report section

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ce095543c8328afc3765c3528c1e4