### PR TITLE
Add date parsing tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ import zipfile
 import pandas as pd
 import json  # NEW: for reading from secrets
 
+from utils import parse_any_date
+
 st.markdown(
     """
     <style>
@@ -203,14 +205,6 @@ from datetime import datetime, timedelta
 from docxtpl import DocxTemplate
 import requests
 
-def parse_any_date(datestr):
-    for fmt in ("%d.%m.%Y", "%d/%m/%Y", "%Y-%m-%d"):
-        try:
-            return datetime.strptime(datestr, fmt).date()
-        except ValueError:
-            continue
-    raise ValueError(f"Unknown date format: {datestr}")
-
 
 # --------------- SETTINGS ---------------
 WEEKLY_TEMPLATE_PATH = "Weekly reports template.docx"
@@ -229,16 +223,6 @@ def generate_hf_summary(text, hf_token):
         return response.json()[0]['summary_text']
     except Exception:
         return "Summary not available. Please check your Hugging Face token or try again later."
-
-st.header("🗓️ Generate Weekly Electrical Consultant Report")
-
-def parse_any_date(datestr):
-    for fmt in ("%d.%m.%Y", "%d/%m/%Y", "%Y-%m-%d"):
-        try:
-            return datetime.strptime(datestr, fmt).date()
-        except ValueError:
-            continue
-    raise ValueError(f"Unknown date format: {datestr}")
 
 st.header("🗓️ Generate Weekly Electrical Consultant Report")
 

--- a/tests/test_parse_any_date.py
+++ b/tests/test_parse_any_date.py
@@ -1,0 +1,19 @@
+import datetime
+import pytest
+
+from utils import parse_any_date
+
+
+@pytest.mark.parametrize("datestr", [
+    "25.12.2023",
+    "25/12/2023",
+    "2023-12-25",
+])
+def test_valid_formats(datestr):
+    expected = datetime.date(2023, 12, 25)
+    assert parse_any_date(datestr) == expected
+
+
+def test_invalid_format():
+    with pytest.raises(ValueError):
+        parse_any_date("12-25-2023")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+
+def parse_any_date(datestr: str):
+    """Parse a date string in multiple formats into a ``datetime.date``.
+
+    Supported formats:
+    - ``dd.mm.YYYY``
+    - ``dd/mm/YYYY``
+    - ``YYYY-mm-dd``
+
+    Parameters
+    ----------
+    datestr: str
+        Date string to parse.
+
+    Returns
+    -------
+    datetime.date
+        Parsed date.
+
+    Raises
+    ------
+    ValueError
+        If ``datestr`` does not match any supported format.
+    """
+    for fmt in ("%d.%m.%Y", "%d/%m/%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(datestr, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Unknown date format: {datestr}")


### PR DESCRIPTION
## Summary
- move `parse_any_date` to new `utils` module
- import the helper in `app.py`
- add pytest coverage for valid/invalid date strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce0a5b4088328922825049b80da51