### PR TITLE
Improve HF summary error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ import zipfile
 import pandas as pd
 import json  # NEW: for reading from secrets
 from datetime import datetime, timedelta
-import requests
 
 from utils import parse_any_date
 
@@ -208,19 +207,8 @@ if st.button("🚀 Generate & Download All Reports"):
 WEEKLY_TEMPLATE_PATH = "Weekly reports template.docx"
 HF_TOKEN = st.secrets.get("HF_TOKEN")
 
-def generate_hf_summary(text, hf_token):
-    API_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
-    headers = {"Authorization": f"Bearer {hf_token}"}
-    prompt = (
-        "You are an experienced electrical engineering consultant. Summarize the following daily site reports "
-        "into a natural, professional, and human-sounding weekly progress summary:\n\n" + text
-    )
-    payload = {"inputs": prompt}
-    response = requests.post(API_URL, headers=headers, json=payload)
-    try:
-        return response.json()[0]['summary_text']
-    except Exception:
-        return "Summary not available. Please check your Hugging Face token or try again later."
+# import the summarization helper from a separate module so it can be tested in isolation
+from summary_utils import generate_hf_summary
 
 
 st.header("🗓️ Generate Weekly Electrical Consultant Report")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-docx
 docxtpl
 pillow
 google-api-python-client
+requests

--- a/summary_utils.py
+++ b/summary_utils.py
@@ -1,0 +1,44 @@
+import logging
+
+try:  # pragma: no cover - requests may not be installed in some environments
+    import requests
+except Exception:  # noqa: BLE001 - any import failure should fallback gracefully
+    requests = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def generate_hf_summary(text: str, hf_token: str) -> str:
+    """Summarize text using Hugging Face's inference API.
+
+    If the request fails or the API returns a non-200 status code, a fallback
+    message is returned and the error is logged.
+    """
+    API_URL = "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"
+    headers = {"Authorization": f"Bearer {hf_token}"}
+    prompt = (
+        "You are an experienced electrical engineering consultant. Summarize the "
+        "following daily site reports into a natural, professional, and human-sounding weekly progress summary:\n\n" + text
+    )
+    payload = {"inputs": prompt}
+
+    if requests is None:
+        logger.warning("requests library is not available")
+        return "Summary not available. Please check your Hugging Face token or try again later."
+
+    try:
+        response = requests.post(API_URL, headers=headers, json=payload)
+    except requests.RequestException as exc:
+        logger.warning("HF API request failed: %s", exc)
+        return "Summary not available. Please check your Hugging Face token or try again later."
+
+    if response.status_code != 200:
+        logger.warning("HF API returned status %s: %s", response.status_code, response.text)
+        return "Summary not available. Please check your Hugging Face token or try again later."
+
+    try:
+        return response.json()[0]["summary_text"]
+    except Exception as exc:  # noqa: BLE001  # allow broad except for robustness
+        logger.warning("Failed to parse HF API response: %s", exc)
+        return "Summary not available. Please check your Hugging Face token or try again later."

--- a/tests/test_generate_hf_summary.py
+++ b/tests/test_generate_hf_summary.py
@@ -1,0 +1,15 @@
+from summary_utils import generate_hf_summary
+from unittest.mock import patch
+
+
+class DummyRequests:
+    class RequestException(Exception):
+        pass
+
+
+def test_generate_hf_summary_request_exception():
+    with patch('summary_utils.requests') as mock_requests:
+        mock_requests.post.side_effect = DummyRequests.RequestException("boom")
+        mock_requests.RequestException = DummyRequests.RequestException
+        result = generate_hf_summary("text", "token")
+    assert result.startswith("Summary not available")


### PR DESCRIPTION
## Summary
- move HuggingFace summary helper to `summary_utils.py`
- handle `requests` failures and HTTP status codes gracefully
- expose summarizer from app
- add regression test for failed API requests
- add `requests` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d53271f588328a100cf66966e05ac