### PR TITLE
Add sidebar status overview metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -531,6 +531,13 @@ if site_date_pairs:
 else:
     st.info("No site/date pairs in current filter. Adjust filters to upload images.")
 
+# Sidebar status overview
+filtered_count = len(filtered_rows)
+total_uploaded_images = sum(len(v) for v in uploaded_image_mapping.values())
+st.sidebar.markdown("### Status Overview")
+st.sidebar.write(f"Filtered rows: {filtered_count}")
+st.sidebar.write(f"Uploaded images: {total_uploaded_images}")
+
 # -----------------------------
 # Generate reports
 # -----------------------------


### PR DESCRIPTION
## Summary
- compute counts for filtered rows and uploaded images
- show status overview in sidebar with total rows and images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1816cb2848328965b405a43aec115