### PR TITLE
Ensure workbook closed in timesheet updater

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,48 +201,51 @@ from io import BytesIO
 
 def update_timesheet_template_by_discipline(template_path, all_rows, selected_dates, discipline):
     wb = load_workbook(template_path)
-    ws = wb.active
+    try:
+        ws = wb.active
 
-    for date_str in selected_dates:
-        try:
-            day_num = int(pd.to_datetime(date_str, dayfirst=True).day)
-        except:
-            continue
+        for date_str in selected_dates:
+            try:
+                day_num = int(pd.to_datetime(date_str, dayfirst=True).day)
+            except:
+                continue
 
-        # Filter rows by date AND discipline
-        day_rows = [
-            r for r in all_rows
-            if r[0] == date_str and st.session_state.get("discipline_radio") == discipline
-        ]
+            # Filter rows by date AND discipline
+            day_rows = [
+                r for r in all_rows
+                if r[0] == date_str and st.session_state.get("discipline_radio") == discipline
+            ]
 
-        if not day_rows:
-            continue
+            if not day_rows:
+                continue
 
-        # Extract site names
-        sites = sorted(set(r[1] for r in day_rows if r[1]))
+            # Extract site names
+            sites = sorted(set(r[1] for r in day_rows if r[1]))
 
-        # Extract and merge activities
-        activities = []
-        for r in day_rows:
-            site = r[1]
-            act1 = r[6] or ""
-            act2 = r[8] or ""
-            combined = " / ".join(filter(None, [act1.strip(), act2.strip()]))
-            if combined:
-                activities.append(f"{site}: {combined}")
+            # Extract and merge activities
+            activities = []
+            for r in day_rows:
+                site = r[1]
+                act1 = r[6] or ""
+                act2 = r[8] or ""
+                combined = " / ".join(filter(None, [act1.strip(), act2.strip()]))
+                if combined:
+                    activities.append(f"{site}: {combined}")
 
-        # Fill Excel row for the matching day number
-        for row in range(19, 60):
-            cell_value = ws[f"A{row}"].value
-            if cell_value == day_num:
-                ws[f"F{row}"] = ", ".join(sites)
-                ws[f"G{row}"] = "\n".join(activities[:8]) or "Supervision of site activities"
-                break
+            # Fill Excel row for the matching day number
+            for row in range(19, 60):
+                cell_value = ws[f"A{row}"].value
+                if cell_value == day_num:
+                    ws[f"F{row}"] = ", ".join(sites)
+                    ws[f"G{row}"] = "\n".join(activities[:8]) or "Supervision of site activities"
+                    break
 
-    output = BytesIO()
-    wb.save(output)
-    output.seek(0)
-    return output
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return output
+    finally:
+        wb.close()
 
 
 
@@ -789,46 +792,49 @@ from io import BytesIO
 
 def update_timesheet_template_by_discipline(template_path, all_rows, selected_dates, discipline):
     wb = load_workbook(template_path)
-    ws = wb.active
+    try:
+        ws = wb.active
 
-    for date_str in selected_dates:
-        try:
-            day_num = int(pd.to_datetime(date_str, dayfirst=True).day)
-        except:
-            continue
+        for date_str in selected_dates:
+            try:
+                day_num = int(pd.to_datetime(date_str, dayfirst=True).day)
+            except:
+                continue
 
-        # Filter rows by date AND discipline
-        day_rows = [
-            r for r in all_rows
-            if r[0] == date_str and st.session_state.get("discipline_radio") == discipline
-        ]
+            # Filter rows by date AND discipline
+            day_rows = [
+                r for r in all_rows
+                if r[0] == date_str and st.session_state.get("discipline_radio") == discipline
+            ]
 
-        if not day_rows:
-            continue
+            if not day_rows:
+                continue
 
-        # Extract site names
-        sites = sorted(set(r[1] for r in day_rows if r[1]))
+            # Extract site names
+            sites = sorted(set(r[1] for r in day_rows if r[1]))
 
-        # Extract and merge activities
-        activities = []
-        for r in day_rows:
-            site = r[1]
-            act1 = r[6] or ""
-            act2 = r[8] or ""
-            combined = " / ".join(filter(None, [act1.strip(), act2.strip()]))
-            if combined:
-                activities.append(f"{site}: {combined}")
+            # Extract and merge activities
+            activities = []
+            for r in day_rows:
+                site = r[1]
+                act1 = r[6] or ""
+                act2 = r[8] or ""
+                combined = " / ".join(filter(None, [act1.strip(), act2.strip()]))
+                if combined:
+                    activities.append(f"{site}: {combined}")
 
-        # Fill Excel row for the matching day number
-        for row in range(19, 60):
-            cell_value = ws[f"A{row}"].value
-            if cell_value == day_num:
-                ws[f"F{row}"] = ", ".join(sites)
-                ws[f"G{row}"] = "\n".join(activities[:8]) or "Supervision of site activities"
-                break
+            # Fill Excel row for the matching day number
+            for row in range(19, 60):
+                cell_value = ws[f"A{row}"].value
+                if cell_value == day_num:
+                    ws[f"F{row}"] = ", ".join(sites)
+                    ws[f"G{row}"] = "\n".join(activities[:8]) or "Supervision of site activities"
+                    break
 
-    output = BytesIO()
-    wb.save(output)
-    output.seek(0)
-    return output
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+        return output
+    finally:
+        wb.close()
 


### PR DESCRIPTION
## Summary
- Safely handle workbook in `update_timesheet_template_by_discipline`
- Guarantee the workbook is closed by wrapping save logic with `try/finally`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d114d9ec8328acc836c1ff3eb42b