### PR TITLE
Use electrical engineer as contractor for civil discipline

### DIFF
--- a/app.py
+++ b/app.py
@@ -475,7 +475,7 @@ SIGNATORIES = {
         # Keep stems; resolver will find .jpg/.png in repo root or ./signatures
         "Consultant_Signature": "iranzi_prince_jean_claude",
         "Contractor_Name": "Issac HABIMANA",
-        "Contractor_Title": "Civil Engineer",
+        "Contractor_Title": "Electrical Engineer",
         "Contractor_Signature": "issac_habimana",
     },
     "Electrical": {


### PR DESCRIPTION
## Summary
- Assign electrical engineer as the contractor for civil discipline sign-off.
- Audited project to remove any references to a civil-side contractor.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad3530d274832886030704ff71fd5d