### PR TITLE
Normalize site/date keys for uploaded images

### DIFF
--- a/app.py
+++ b/app.py
@@ -407,6 +407,8 @@ if show_dashboard:
 # Image upload UI
 st.subheader("Gallery Preview & Customization")
 for site_name, date in site_date_pairs:
+    site_name = site_name.strip()
+    date = date.strip()
     image_files = uploaded_image_mapping.get((site_name, date), []) or []
     if image_files:
         st.markdown(f"**Gallery for {site_name} ({date})**")
@@ -419,6 +421,8 @@ for site_name, date in site_date_pairs:
 
 if site_date_pairs:
     for site_name, date in site_date_pairs:
+        site_name = site_name.strip()
+        date = date.strip()
         with st.expander(f"Upload Images for {site_name} ({date})"):
             imgs = st.file_uploader(
                 f"Images for {site_name} ({date})",
@@ -442,6 +446,9 @@ if st.button("🚀 Generate & Download All Reports"):
                     work_executed, comment_on_work, another_work_executed,
                     comment_on_hse, consultant_recommandation
                 ) = (row + [""] * 11)[:11]
+
+                date = date.strip()
+                site_name = site_name.strip()
 
                 tpl = DocxTemplate(TEMPLATE_PATH)
 


### PR DESCRIPTION
## Summary
- strip whitespace from site name and date before forming keys for the uploaded image mapping
- ensure retrieval during gallery preview, upload, and report generation uses normalized keys

## Testing
- `pytest`
- `python manual_doc_test.py` *(inline script verifying retrieval and document contains uploaded image)*

------
https://chatgpt.com/codex/tasks/task_b_68c59a0f0ba4832ab5cdaf7352d39f91