### PR TITLE
Handle offline cache on Google Sheet sync failure

### DIFF
--- a/app.py
+++ b/app.py
@@ -311,19 +311,6 @@ img_per_row = st.sidebar.selectbox("Images per row", options=[1,2,3,4], index=1)
 add_border = st.sidebar.checkbox("Add border to images", value=False)
 spacing_mm = st.sidebar.slider("Spacing between images (mm)", min_value=0, max_value=20, value=2, step=1)
 
-# Get sheet data
-cache = load_offline_cache()
-if cache and cache.get("rows"):
-    st.info("Cached offline data detected. Use the button below to sync back to the Google Sheet.")
-    if st.button("Sync cached data to Google Sheet"):
-        try:
-            append_rows_to_sheet(cache.get("rows", []))
-            CACHE_FILE.unlink()
-            st.success("Cached data synced to Google Sheet.")
-            cache = None
-        except Exception as e:
-            st.error(f"Sync failed: {e}")
-
 try:
     rows = get_sheet_data()
 except Exception as e:
@@ -432,6 +419,21 @@ if site_date_pairs:
             uploaded_image_mapping[(site_name, date)] = imgs
 else:
     st.info("No site/date pairs in current filter. Adjust filters to upload images.")
+
+cache = load_offline_cache()
+if cache and cache.get("rows"):
+    st.info("Cached offline data detected. Use the button below to sync back to the Google Sheet.")
+    if st.button("Sync cached data to Google Sheet"):
+        try:
+            append_rows_to_sheet(cache.get("rows", []))
+            if CACHE_FILE.exists():
+                CACHE_FILE.unlink()
+            st.success("Cached data synced to Google Sheet.")
+            cache = None
+        except Exception as e:
+            st.error(f"Sync failed: {e}")
+            if offline_enabled:
+                save_offline_cache(filtered_rows, uploaded_image_mapping)
 
 # -----------------------------
 # Generate reports


### PR DESCRIPTION
## Summary
- Save current rows and image uploads to offline cache if syncing to Google Sheets fails while offline cache is enabled
- Remove offline cache file after successful sync to prevent duplicate uploads

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c59c032f14832abf4e3cf1fe4a3aa2