### PR TITLE
feat: add configurable settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ GOOGLE_CREDENTIALS = """
 The credentials are parsed with `json.loads(st.secrets["GOOGLE_CREDENTIALS"])`
 when the app starts.
 
+## Configuration
+
+Application settings can be supplied through environment variables or by
+placing a `config.json` or `config.toml` file in the project root.  A custom
+configuration file path may also be provided via the `APP_CONFIG` environment
+variable.  Settings from environment variables take precedence over values from
+the configuration file.
+
+Supported options:
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `TEMPLATE_PATH` | Path to the Word report template used when generating documents. | `Site_Daily_report_Template_Date.docx` |
+| `SHEET_ID` | ID of the Google Sheet that stores report data. | `1t6Bmm3YN7mAovNM3iT7oMGeXG3giDONSejJ9gUbUeCI` |
+| `SHEET_NAME` | Worksheet within the Google Sheet from which to read data. | `Reports` |
+| `CACHE_FILE` | File used to cache offline data before syncing. | `offline_cache.json` in the project directory |
+| `DISCIPLINE_COL` | Column number for the "Discipline" field in the sheet. | `11` |
+
+Example `config.toml`:
+
+```toml
+SHEET_ID = "your-google-sheet-id"
+SHEET_NAME = "Reports"
+```
+
 ## Google Sheet Setup
 
 The app expects data in a Google Sheet named **Reports**. Columns **A** through

--- a/app.py
+++ b/app.py
@@ -17,17 +17,19 @@ from docxtpl import DocxTemplate, InlineImage
 from docx.shared import Mm
 from docx import Document
 from openpyxl import load_workbook
+from config import (
+    BASE_DIR,
+    TEMPLATE_PATH,
+    SHEET_ID,
+    SHEET_NAME,
+    CACHE_FILE,
+    DISCIPLINE_COL,
+)
 
 # -----------------------------
 # Globals
 # -----------------------------
-BASE_DIR = Path(__file__).parent.resolve()
-TEMPLATE_PATH = "Site_Daily_report_Template_Date.docx"
-SHEET_ID = "1t6Bmm3YN7mAovNM3iT7oMGeXG3giDONSejJ9gUbUeCI"
-SHEET_NAME = "Reports"
-CACHE_FILE = BASE_DIR / "offline_cache.json"
 
-DISCIPLINE_COL = 11  # (kept from original)
 
 # -----------------------------
 # Utility functions

--- a/config.py
+++ b/config.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    import tomli as tomllib  # type: ignore
+
+BASE_DIR = Path(__file__).parent.resolve()
+
+
+def _load_file(path: Path) -> Dict[str, Any]:
+    """Load a JSON or TOML configuration file."""
+    if path.suffix.lower() == ".json":
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    if path.suffix.lower() in {".toml", ".tml"}:
+        with open(path, "rb") as fh:
+            return tomllib.load(fh)
+    return {}
+
+
+def _load_config() -> Dict[str, Any]:
+    """Search for a configuration file and return its contents.
+
+    Lookup order:
+      1. Path from the ``APP_CONFIG`` environment variable.
+      2. ``config.json`` in the project root.
+      3. ``config.toml`` in the project root.
+    """
+    candidates = []
+    env_path = os.environ.get("APP_CONFIG")
+    if env_path:
+        candidates.append(Path(env_path))
+    candidates.append(BASE_DIR / "config.json")
+    candidates.append(BASE_DIR / "config.toml")
+
+    for path in candidates:
+        if path.is_file():
+            try:
+                return _load_file(path)
+            except Exception:
+                return {}
+    return {}
+
+
+_CONFIG = _load_config()
+
+
+def _get(name: str, default: Any) -> Any:
+    """Return a configuration value.
+
+    Environment variables override values from configuration files."""
+    return os.environ.get(name, _CONFIG.get(name, default))
+
+
+TEMPLATE_PATH = _get("TEMPLATE_PATH", "Site_Daily_report_Template_Date.docx")
+SHEET_ID = _get("SHEET_ID", "1t6Bmm3YN7mAovNM3iT7oMGeXG3giDONSejJ9gUbUeCI")
+SHEET_NAME = _get("SHEET_NAME", "Reports")
+CACHE_FILE = Path(_get("CACHE_FILE", BASE_DIR / "offline_cache.json"))
+DISCIPLINE_COL = int(_get("DISCIPLINE_COL", 11))
+
+__all__ = [
+    "BASE_DIR",
+    "TEMPLATE_PATH",
+    "SHEET_ID",
+    "SHEET_NAME",
+    "CACHE_FILE",
+    "DISCIPLINE_COL",
+]


### PR DESCRIPTION
## Summary
- load runtime settings from `config.py`
- document configuration options in the README
- use imported constants in `app.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c59c1291fc832a8818c310cc420f6b