### PR TITLE
Initialize UI with background and branded header

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,9 +9,13 @@ from sheets import (
     load_offline_cache,
 )
 
+from ui import render_workwatch_header, set_background
+
 
 def run_app():
     """Render the Streamlit interface."""
+    set_background("bg.jpg")
+    render_workwatch_header()
 
     # Controls that were mistakenly embedded in HTML in original file:
     st.sidebar.subheader("Gallery Controls")


### PR DESCRIPTION
## Summary
- Import background and header utilities from `ui.py`
- Set background image and render branded header at start of `run_app`

## Testing
- `pytest tests/test_ui_module.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5a61be464832a9e209cad3288ad8d