### PR TITLE
Add discipline selection and report generation UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from sheets import (
 )
 
 from ui import render_workwatch_header, set_background
+from report import generate_reports
 
 
 def run_app():
@@ -100,6 +101,29 @@ def run_app():
         ],
     )
     st.dataframe(df_preview)
+
+    discipline = st.radio("Discipline", ["Civil", "Electrical"], key="discipline_radio")
+
+    for site, date in site_date_pairs:
+        files = st.file_uploader(
+            f"Upload images for {site} - {date}",
+            accept_multiple_files=True,
+            type=["png", "jpg", "jpeg", "webp"],
+            key=f"uploader_{site}_{date}",
+        )
+        if files:
+            uploaded_image_mapping[(site.strip(), date.strip())] = files
+
+    if st.button("Generate Reports"):
+        zip_bytes = generate_reports(
+            filtered_rows,
+            uploaded_image_mapping,
+            discipline,
+            img_width_mm,
+            img_per_row,
+            add_border,
+        )
+        st.download_button("Download ZIP", zip_bytes, "reports.zip")
 
 
 if __name__ == "__main__":

--- a/report.py
+++ b/report.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import streamlit as st
 from docxtpl import DocxTemplate, InlineImage
 from docx.shared import Mm
 
@@ -98,10 +99,24 @@ def generate_reports(
                 work_executed, comment_on_work, another_work_executed,
                 comment_on_hse, consultant_recommandation
             ) = (row + [""] * 11)[:11]
-            date = date.strip()
             site_name = site_name.strip()
+            date = date.strip()
 
             tpl = DocxTemplate(template_path)
+            required = {
+                "Consultant_Name",
+                "Consultant_Title",
+                "Consultant_Signature",
+                "Contractor_Name",
+                "Contractor_Title",
+                "Contractor_Signature",
+            }
+            placeholders = tpl.get_undeclared_template_variables({})
+            missing = required - placeholders
+            if missing:
+                st.warning(
+                    "Template is missing placeholders: " + ", ".join(sorted(missing))
+                )
 
             image_files = uploaded_image_mapping.get((site_name, date), []) or []
             images_subdoc = tpl.new_subdoc()


### PR DESCRIPTION
## Summary
- Wrap Streamlit UI in `run_app` and brand with background and header
- Add discipline selection, per-site image uploaders, and ZIP report download
- Normalize gallery keys and autofill consultant/contractor signatures with template validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5a7e028dc832a9dff6d035c7b7046