### PR TITLE
Align gallery placeholder with Images key

### DIFF
--- a/report.py
+++ b/report.py
@@ -177,7 +177,7 @@ def generate_reports(
                 "Contractor_Title": sign_info.get("Contractor_Title", ""),
                 "Consultant_Signature": cons_sig_img,
                 "Contractor_Signature": cont_sig_img,
-                "Gallery": images_subdoc,
+                "Images": images_subdoc,
             }
 
             tpl.render(ctx)


### PR DESCRIPTION
## Summary
- Use `Images` context key when rendering reports so uploaded photos show up under the Gallery section

## Testing
- `python - <<'PY' ...` *(generate report snippet in analysis? But we can't embed long Python output; maybe we can mention we generated a sample report)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c5aef431ac832ab2ada03570c07f1c