### PR TITLE
Add Streamlit helper for Google Sheet access

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import streamlit as st
+import gspread
+from google.oauth2.service_account import Credentials
 
 from sheets import (
     CACHE_FILE,
@@ -11,6 +13,17 @@ from sheets import (
 
 from ui import render_workwatch_header, set_background
 from report import generate_reports
+
+
+def get_gsheet(sheet_id: str, sheet_name: str):
+    """Return a gspread worksheet for the given sheet ID and worksheet name."""
+    service_account_info = st.secrets["gcp_service_account"]
+    credentials = Credentials.from_service_account_info(
+        service_account_info,
+        scopes=["https://www.googleapis.com/auth/spreadsheets"],
+    )
+    client = gspread.authorize(credentials)
+    return client.open_by_key(sheet_id).worksheet(sheet_name)
 
 
 def run_app():


### PR DESCRIPTION
## Summary
- add a `get_gsheet` helper in the Streamlit app to authorize with gspread via service account secrets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8401bda4832cb65564ac97ecc946