### PR TITLE
Use configurable paths for sheets and template

### DIFF
--- a/report.py
+++ b/report.py
@@ -9,8 +9,9 @@ import streamlit as st
 from docxtpl import DocxTemplate, InlineImage
 from docx.shared import Mm
 
+from config import TEMPLATE_PATH
+
 BASE_DIR = Path(__file__).parent.resolve()
-TEMPLATE_PATH = "Site_Daily_report_Template_Date.docx"
 
 SIGNATORIES = {
     "Civil": {

--- a/sheets.py
+++ b/sheets.py
@@ -1,16 +1,13 @@
 import base64
 import json
-from pathlib import Path
 from typing import Dict, List
 
 import streamlit as st
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
-BASE_DIR = Path(__file__).parent.resolve()
-SHEET_ID = "1t6Bmm3YN7mAovNM3iT7oMGeXG3giDONSejJ9gUbUeCI"
-SHEET_NAME = "Reports"
-CACHE_FILE = BASE_DIR / "offline_cache.json"
+from config import CACHE_FILE, SHEET_ID, SHEET_NAME
+
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
 


### PR DESCRIPTION
## Summary
- update the sheets module to source the sheet id, sheet name, and cache file path from the shared config
- have the report module import the template path from the shared config so it can be overridden externally

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca942b1a84832c9d4044a05ff58553