### PR TITLE
Align Google credential loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ GOOGLE_CREDENTIALS = """
 ```
 
 The credentials are parsed with `json.loads(st.secrets["GOOGLE_CREDENTIALS"])`
-when the app starts.
+when the app starts. For backwards compatibility, an older
+`gcp_service_account` key is also accepted if present.
 
 ## Configuration
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import streamlit as st
 import gspread
-from google.oauth2.service_account import Credentials
 
 from config import SHEET_ID, SHEET_NAME
 
@@ -11,6 +10,7 @@ from sheets import (
     get_sheet_data,
     get_unique_sites_and_dates,
     load_offline_cache,
+    get_service_account_credentials,
 )
 
 from ui import render_workwatch_header, set_background
@@ -19,11 +19,7 @@ from report import generate_reports
 
 def get_gsheet(sheet_id: str, sheet_name: str):
     """Return a gspread worksheet for the given sheet ID and worksheet name."""
-    service_account_info = st.secrets["gcp_service_account"]
-    credentials = Credentials.from_service_account_info(
-        service_account_info,
-        scopes=["https://www.googleapis.com/auth/spreadsheets"],
-    )
+    credentials = get_service_account_credentials()
     client = gspread.authorize(credentials)
     return client.open_by_key(sheet_id).worksheet(sheet_name)
 


### PR DESCRIPTION
## Summary
- add a shared helper that loads Google service account credentials from Streamlit secrets with a fallback to the legacy key
- update Sheets API and gspread paths to reuse the same credential loader
- document the optional legacy secret key in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca942d5dc8832caf6d341f0f5b5baf