### PR TITLE
Switch report helper to Hugging Face inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This Streamlit app helps generate daily electrical consultant reports.
 
+## Configuring AI Structuring Support
+
+The helper that structures pasted reports now calls a Hugging Face Inference
+Endpoint. Provide an access token under the `HUGGINGFACE_API_KEY` secret in your
+`.streamlit/secrets.toml` file:
+
+```
+# .streamlit/secrets.toml
+HUGGINGFACE_API_KEY = "hf_xxx"
+```
+
+The token must have permission to query the model configured in
+`chatgpt_helpers.MODEL_ID` (default: `mistralai/Mistral-7B-Instruct`).
+
 ## Providing Google Credentials
 
 The app also needs access to your reporting Google Sheet. Create a Google

--- a/chatgpt_helpers.py
+++ b/chatgpt_helpers.py
@@ -1,4 +1,4 @@
-"""Utilities for structuring contractor reports using OpenAI's Chat Completions API."""
+"""Utilities for structuring contractor reports using Hugging Face text generation."""
 from __future__ import annotations
 
 import json
@@ -21,7 +21,8 @@ REPORT_HEADERS: List[str] = [
     "Consultant_Recommandation",
 ]
 
-_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
+MODEL_ID = "mistralai/Mistral-7B-Instruct"
+_INFERENCE_URL = f"https://api-inference.huggingface.co/models/{MODEL_ID}"
 _PROMPT_TEMPLATE = """You are a meticulous assistant that converts contractor site reports into
 structured data. Map the provided text into the following columns exactly:
 {headers}.
@@ -38,7 +39,7 @@ Raw report:\n{report_text}
 def clean_and_structure_report(
     raw_report_text: str,
 ) -> Union[Dict[str, str], List[Dict[str, str]]]:
-    """Use OpenAI Chat Completions to structure a raw contractor report.
+    """Use a Hugging Face text-generation model to structure a raw contractor report.
 
     Parameters
     ----------
@@ -54,7 +55,7 @@ def clean_and_structure_report(
     Raises
     ------
     RuntimeError
-        If the API key is missing or the OpenAI API request fails.
+        If the API key is missing or the Hugging Face API request fails.
     ValueError
         If the raw report text is empty or the response cannot be normalised.
     """
@@ -63,31 +64,22 @@ def clean_and_structure_report(
         raise ValueError("Raw report text is empty.")
 
     try:
-        api_key = st.secrets["OPENAI_API_KEY"]
+        api_key = st.secrets["HUGGINGFACE_API_KEY"]
     except Exception as exc:  # pragma: no cover - defensive access to secrets
         raise RuntimeError(
-            "OpenAI API key is not configured. Set OPENAI_API_KEY in Streamlit secrets."
+            "Hugging Face API key is not configured. Set HUGGINGFACE_API_KEY in Streamlit secrets."
         ) from exc
-
+    prompt = _PROMPT_TEMPLATE.format(
+        headers=", ".join(REPORT_HEADERS), report_text=raw_report_text
+    )
     payload = {
-        "model": "gpt-4o-mini",
-        "temperature": 0,
-        "messages": [
-            {
-                "role": "system",
-                "content": "You extract tabular data from contractor reports.",
-            },
-            {
-                "role": "user",
-                "content": _PROMPT_TEMPLATE.format(
-                    headers=", ".join(REPORT_HEADERS), report_text=raw_report_text
-                ),
-            },
-        ],
+        "inputs": prompt,
+        "parameters": {"temperature": 0.0, "max_new_tokens": 800},
+        "options": {"wait_for_model": True},
     }
 
     http_request = request.Request(
-        _CHAT_COMPLETIONS_URL,
+        _INFERENCE_URL,
         data=json.dumps(payload).encode("utf-8"),
         headers={
             "Content-Type": "application/json",
@@ -101,21 +93,37 @@ def clean_and_structure_report(
             raw_body = response.read().decode("utf-8")
     except error.HTTPError as exc:
         error_details = _read_error_body(exc)
-        message = error_details or exc.reason or str(exc.code)
-        raise RuntimeError(f"OpenAI API error ({exc.code}): {message}") from exc
+        message = _extract_error_message(error_details) or exc.reason or str(exc.code)
+        raise RuntimeError(f"Hugging Face API error ({exc.code}): {message}") from exc
     except error.URLError as exc:
-        raise RuntimeError(f"Failed to contact OpenAI API: {exc.reason}") from exc
-
+        raise RuntimeError(f"Failed to contact Hugging Face API: {exc.reason}") from exc
     try:
         response_json = json.loads(raw_body)
-        content = response_json["choices"][0]["message"]["content"]
-    except (json.JSONDecodeError, KeyError, IndexError) as exc:
-        raise RuntimeError("Unexpected response from OpenAI API.") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Unexpected response from Hugging Face API.") from exc
+
+    if isinstance(response_json, dict) and "error" in response_json:
+        raise RuntimeError(f"Hugging Face API error: {response_json['error']}")
+
+    if not isinstance(response_json, list) or not response_json:
+        raise RuntimeError("Unexpected response from Hugging Face API.")
+
+    first_item = response_json[0]
+    if not isinstance(first_item, dict):
+        raise RuntimeError("Unexpected response from Hugging Face API.")
+
+    generated_text = first_item.get("generated_text")
+    if not generated_text:
+        error_message = _extract_error_message(raw_body) or "Missing generated_text in response."
+        raise RuntimeError(f"Hugging Face API error: {error_message}")
+
+    if generated_text.startswith(prompt):
+        generated_text = generated_text[len(prompt) :]
 
     try:
-        parsed_payload = _parse_json_content(content)
+        parsed_payload = _parse_json_content(generated_text)
     except json.JSONDecodeError as exc:
-        raise RuntimeError("ChatGPT response could not be parsed as JSON.") from exc
+        raise RuntimeError("Hugging Face response could not be parsed as JSON.") from exc
 
     try:
         normalised_rows = _normalise_payload(parsed_payload)
@@ -154,7 +162,7 @@ def _normalise_payload(data: Any) -> List[Dict[str, str]]:
         return [_normalise_row(data)]
     if isinstance(data, list):
         return [_normalise_row(item) for item in data]
-    raise ValueError("ChatGPT response must be a JSON object or list of objects.")
+    raise ValueError("Model response must be a JSON object or list of objects.")
 
 
 def _normalise_row(item: Any) -> Dict[str, str]:
@@ -176,3 +184,22 @@ def _read_error_body(exc: error.HTTPError) -> str:
     except Exception:  # pragma: no cover - fallback if body cannot be read
         return ""
     return body.strip()
+
+
+def _extract_error_message(body: str) -> str:
+    if not body:
+        return ""
+    try:
+        parsed_body = json.loads(body)
+    except json.JSONDecodeError:
+        return body.strip()
+
+    if isinstance(parsed_body, dict):
+        error_message = parsed_body.get("error")
+        if error_message:
+            return str(error_message)
+    if isinstance(parsed_body, list):
+        for item in parsed_body:
+            if isinstance(item, dict) and item.get("error"):
+                return str(item["error"])
+    return ""

--- a/tests/test_chatgpt_helpers.py
+++ b/tests/test_chatgpt_helpers.py
@@ -1,0 +1,83 @@
+import json
+from typing import Any
+
+import pytest
+
+import chatgpt_helpers
+
+
+class DummyResponse:
+    def __init__(self, body: str, status: int = 200):
+        self._body = body.encode("utf-8")
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "DummyResponse":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        return None
+
+
+def test_clean_and_structure_report_huggingface_payload(monkeypatch):
+    raw_report = "Crew installed transformers."
+    prompt = chatgpt_helpers._PROMPT_TEMPLATE.format(
+        headers=", ".join(chatgpt_helpers.REPORT_HEADERS),
+        report_text=raw_report,
+    )
+    response_payload = {
+        header: f"value-{index}"
+        for index, header in enumerate(chatgpt_helpers.REPORT_HEADERS)
+    }
+    generated_text = prompt + json.dumps(response_payload)
+
+    captured_request = {}
+
+    def fake_urlopen(req, timeout):  # pragma: no cover - exercised via helper
+        captured_request["data"] = req.data
+        captured_request["headers"] = req.headers
+        body = json.dumps([{"generated_text": generated_text}])
+        return DummyResponse(body)
+
+    monkeypatch.setattr(chatgpt_helpers.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        chatgpt_helpers.st,
+        "secrets",
+        {"HUGGINGFACE_API_KEY": "hf-test-token"},
+        raising=False,
+    )
+
+    result = chatgpt_helpers.clean_and_structure_report(raw_report)
+
+    assert result == response_payload
+
+    sent_payload = json.loads(captured_request["data"].decode("utf-8"))
+    assert sent_payload["inputs"] == prompt
+    assert sent_payload["parameters"] == {"temperature": 0.0, "max_new_tokens": 800}
+    assert sent_payload["options"] == {"wait_for_model": True}
+
+    headers = {key.lower(): value for key, value in captured_request["headers"].items()}
+    assert headers["content-type"] == "application/json"
+    assert headers["authorization"] == "Bearer hf-test-token"
+
+
+def test_clean_and_structure_report_missing_generated_text(monkeypatch):
+    monkeypatch.setattr(
+        chatgpt_helpers.st,
+        "secrets",
+        {"HUGGINGFACE_API_KEY": "hf-test-token"},
+        raising=False,
+    )
+
+    def fake_urlopen(req, timeout):  # pragma: no cover - exercised via helper
+        body = json.dumps([{"error": "Model is loading"}])
+        return DummyResponse(body)
+
+    monkeypatch.setattr(chatgpt_helpers.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        chatgpt_helpers.clean_and_structure_report("data")
+
+    assert "Model is loading" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- swap the report structuring helper from OpenAI chat completions to the Hugging Face inference endpoint and harden error handling
- add unit coverage that exercises Hugging Face style responses and validates the request payload and normalisation
- document the new HUGGINGFACE_API_KEY secret required to call the inference endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce61ddb524832ca01f4c9a8de09847