### PR TITLE
Update UI terminology for report processing assistant

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def run_app():
     set_background("bg.jpg")
     render_workwatch_header()
 
-    st.session_state.setdefault("chatgpt_report_data", None)
+    st.session_state.setdefault("structured_report_data", None)
 
     # Controls that were mistakenly embedded in HTML in original file:
     st.sidebar.subheader("Gallery Controls")
@@ -118,13 +118,13 @@ def run_app():
 
     site_date_pairs = sorted({(row[1].strip(), row[0].strip()) for row in filtered_rows})
 
-    st.subheader("Process Contractor Report with ChatGPT")
+    st.subheader("Process Contractor Report with Hugging Face")
     raw_report_text = st.text_area(
         "Paste the contractor's raw report:",
-        key="chatgpt_raw_report_text",
+        key="structured_raw_report_text",
         height=300,
     )
-    if st.button("Clean & Structure with ChatGPT"):
+    if st.button("Clean & Structure with Hugging Face"):
         if not raw_report_text.strip():
             st.warning("Please paste the contractor report before processing.")
         else:
@@ -133,10 +133,10 @@ def run_app():
             except ValueError as exc:
                 st.warning(str(exc))
             except Exception as exc:  # pragma: no cover - user notification
-                st.error(f"ChatGPT processing failed: {exc}")
+                st.error(f"Hugging Face processing failed: {exc}")
             else:
-                st.session_state["chatgpt_report_data"] = structured_payload
-                st.success("Report processed with ChatGPT.")
+                st.session_state["structured_report_data"] = structured_payload
+                st.success("Report processed with Hugging Face.")
 
     # Preview
     st.subheader("Preview Reports to be Generated")
@@ -179,25 +179,25 @@ def run_app():
             for row in filtered_rows
         ]
         if structured_rows:
-            st.session_state["chatgpt_report_data"] = (
+            st.session_state["structured_report_data"] = (
                 structured_rows[0]
                 if len(structured_rows) == 1
                 else structured_rows
             )
         else:
-            st.session_state["chatgpt_report_data"] = None
+            st.session_state["structured_report_data"] = None
 
-    chatgpt_report = st.session_state.get("chatgpt_report_data")
-    if chatgpt_report is not None:
+    structured_report = st.session_state.get("structured_report_data")
+    if structured_report is not None:
         st.subheader("Generated Report JSON")
-        st.json(chatgpt_report)
+        st.json(structured_report)
         if st.button("Send to Google Sheet"):
             try:
                 worksheet = get_gsheet(SHEET_ID, SHEET_NAME)
                 rows_to_append = (
-                    chatgpt_report
-                    if isinstance(chatgpt_report, list)
-                    else [chatgpt_report]
+                    structured_report
+                    if isinstance(structured_report, list)
+                    else [structured_report]
                 )
                 for row_payload in rows_to_append:
                     if not isinstance(row_payload, dict):

--- a/chatgpt_helpers.py
+++ b/chatgpt_helpers.py
@@ -115,7 +115,7 @@ def clean_and_structure_report(
     try:
         parsed_payload = _parse_json_content(content)
     except json.JSONDecodeError as exc:
-        raise RuntimeError("ChatGPT response could not be parsed as JSON.") from exc
+        raise RuntimeError("Model response could not be parsed as JSON.") from exc
 
     try:
         normalised_rows = _normalise_payload(parsed_payload)
@@ -154,7 +154,7 @@ def _normalise_payload(data: Any) -> List[Dict[str, str]]:
         return [_normalise_row(data)]
     if isinstance(data, list):
         return [_normalise_row(item) for item in data]
-    raise ValueError("ChatGPT response must be a JSON object or list of objects.")
+    raise ValueError("Model response must be a JSON object or list of objects.")
 
 
 def _normalise_row(item: Any) -> Dict[str, str]:

--- a/tests/test_app_module.py
+++ b/tests/test_app_module.py
@@ -53,7 +53,7 @@ class _StreamlitStub:
             "Sync cached data to Google Sheet": False,
             "Generate Reports": True,
             "Send to Google Sheet": False,
-            "Clean & Structure with ChatGPT": False,
+            "Clean & Structure with Hugging Face": False,
         }
 
     def columns(self, *_):
@@ -168,13 +168,13 @@ def test_run_app_excludes_header_rows(monkeypatch):
         "Upload images for Site B - 2024-01-02",
     ]
 
-    chatgpt_report = st_stub.session_state.get("chatgpt_report_data")
-    assert isinstance(chatgpt_report, list)
-    assert [row["Site_Name"] for row in chatgpt_report] == ["Site A", "Site B"]
-    assert st_stub.json_value == chatgpt_report
+    structured_report = st_stub.session_state.get("structured_report_data")
+    assert isinstance(structured_report, list)
+    assert [row["Site_Name"] for row in structured_report] == ["Site A", "Site B"]
+    assert st_stub.json_value == structured_report
 
 
-def test_run_app_uses_chatgpt_helper_when_button_clicked(monkeypatch):
+def test_run_app_uses_helper_when_button_clicked(monkeypatch):
     sheet_rows = [
         HEADERS,
         [
@@ -210,11 +210,11 @@ def test_run_app_uses_chatgpt_helper_when_button_clicked(monkeypatch):
     st_stub = _StreamlitStub()
     st_stub.text_area_value = "Sample contractor report"
     st_stub.button_states["Generate Reports"] = False
-    st_stub.button_states["Clean & Structure with ChatGPT"] = True
+    st_stub.button_states["Clean & Structure with Hugging Face"] = True
     monkeypatch.setattr(app, "st", st_stub)
 
     app.run_app()
 
     assert captured_text == ["Sample contractor report"]
-    assert st_stub.session_state["chatgpt_report_data"] == canned_payload
+    assert st_stub.session_state["structured_report_data"] == canned_payload
     assert st_stub.json_value == canned_payload


### PR DESCRIPTION
## Summary
- replace Streamlit UI references to ChatGPT with Hugging Face terminology and rename related session keys
- keep structured report state consistent when generating reports and presenting JSON previews
- refresh tests and helper error messages to follow the provider-neutral wording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce61d813ac832cb833ff78ca1f12f8