### PR TITLE
docs: describe offline structuring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,37 @@
 
 This Streamlit app helps generate daily electrical consultant reports.
 
-## Configuring AI Structuring Support
+## Structuring Contractor Reports Offline
 
-The helper that structures pasted reports now calls a Hugging Face Inference
-Endpoint. Provide an access token under the `HUGGINGFACE_API_KEY` secret in your
-`.streamlit/secrets.toml` file:
+The app no longer relies on a hosted AI service for turning raw contractor
+notes into tabular data. When you need assistance preparing a report, run the
+parser locally and review the JSON it produces before loading it into the app.
 
+1. Save the contractor narrative to a text file while you are on site.
+2. Process that file with your offline parser so that the output JSON contains
+   the columns listed in [Google Sheet Setup](#google-sheet-setup) (for example,
+   `Date`, `Site_Name`, `Work`, and so on).
+3. Inspect the JSON and make any corrections that are needed.
+4. Open the Streamlit app and paste the JSON into the "Generated Report JSON"
+   panel. The app will treat it exactly like a structured payload generated
+   online and will allow you to send the results to Google Sheets or cache them
+   locally.
+
+If you want the app to surface the payload automatically when you next connect,
+store it in the offline cache file (`offline_cache.json`) using the following
+shape:
+
+```json
+{
+  "rows": [
+    ["2024-01-01", "Site A", "District 1", "Work details", "Crew", "Supply", "Executed", "Comment", "Additional work", "HSE", "Recommendation"]
+  ],
+  "uploads": {}
+}
 ```
-# .streamlit/secrets.toml
-HUGGINGFACE_API_KEY = "hf_xxx"
-```
 
-The token must have permission to query the model configured in
-`chatgpt_helpers.MODEL_ID` (default: `mistralai/Mistral-7B-Instruct`).
+Any cached payload will be offered for upload as soon as the app starts, making
+it easy to sync structured notes once you regain connectivity.
 
 ## Providing Google Credentials
 


### PR DESCRIPTION
## Summary
- update the README to describe the offline workflow for preparing structured contractor reports
- provide guidance on how to cache structured payloads locally so they can be synced later
- remove outdated references to Hugging Face tokens and chatgpt_helpers

## Testing
- no tests were run (not required for documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cfc34f2d84832c9fc4a1e29f9168f9