### PR TITLE
Adjust two-column image sizing

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,9 @@ def run_app():
     img_per_row = st.sidebar.selectbox(
         "Images per row", options=[1, 2, 3, 4], index=1
     )
+    st.sidebar.caption(
+        "Selecting two images per row enforces fixed sizing (819×819 px left, 613×818 px right)."
+    )
     add_border = st.sidebar.checkbox("Add border to images", value=False)
     spacing_mm = st.sidebar.slider(
         "Spacing between images (mm)", min_value=0, max_value=20, value=2, step=1


### PR DESCRIPTION
## Summary
- add a pixel-to-millimetre helper and apply fixed dimensions for two-column image layouts
- note the enforced sizing in the sidebar controls

## Testing
- python -m compileall report.py app.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4ca2424c832c8a5347707475f9f9