### PR TITLE
Refine reporting workspace presentation and filter UX

### DIFF
--- a/streamlit_ui/helpers.py
+++ b/streamlit_ui/helpers.py
@@ -34,6 +34,16 @@ def safe_columns(*args, **kwargs):
     return tuple(columns_list)
 
 
+def safe_container(*, border: bool = False):
+    container_fn = getattr(st, "container", None)
+    if callable(container_fn):
+        try:
+            return container_fn(border=border)
+        except TypeError:
+            return container_fn()
+    return nullcontext()
+
+
 def safe_markdown(markdown: str, **kwargs) -> None:
     markdown_fn = getattr(st, "markdown", None)
     if callable(markdown_fn):
@@ -105,6 +115,53 @@ def safe_selectbox(label: str, options: list[str], index: int = 0, **kwargs):
     return options[safe_index]
 
 
+def safe_radio(label: str, options: list[str], index: int = 0, **kwargs):
+    radio_fn = getattr(st, "radio", None)
+    if callable(radio_fn):
+        try:
+            return radio_fn(label, options, index=index, **kwargs)
+        except TypeError:
+            try:
+                return radio_fn(label, options, index=index)
+            except TypeError:
+                return radio_fn(label, options)
+    if not options:
+        return None
+    safe_index = max(0, min(index, len(options) - 1))
+    return options[safe_index]
+
+
+def safe_multiselect(label: str, options: list[str], default=None, **kwargs):
+    multiselect_fn = getattr(st, "multiselect", None)
+    resolved_default = list(default or [])
+    if callable(multiselect_fn):
+        try:
+            return multiselect_fn(label, options, default=resolved_default, **kwargs)
+        except TypeError:
+            try:
+                return multiselect_fn(label, options, resolved_default)
+            except TypeError:
+                return multiselect_fn(label, options)
+    return resolved_default
+
+
+def safe_slider(label: str, *, min_value, max_value, value, step=1, **kwargs):
+    slider_fn = getattr(st, "slider", None)
+    if callable(slider_fn):
+        try:
+            return slider_fn(
+                label,
+                min_value=min_value,
+                max_value=max_value,
+                value=value,
+                step=step,
+                **kwargs,
+            )
+        except TypeError:
+            return slider_fn(label, min_value, max_value, value, step)
+    return value
+
+
 def safe_file_uploader(label: str, **kwargs):
     uploader_fn = getattr(st, "file_uploader", None)
     if callable(uploader_fn):
@@ -112,6 +169,16 @@ def safe_file_uploader(label: str, **kwargs):
     if kwargs.get("accept_multiple_files"):
         return []
     return None
+
+
+def safe_button(label: str, **kwargs) -> bool:
+    button_fn = getattr(st, "button", None)
+    if callable(button_fn):
+        try:
+            return bool(button_fn(label, **kwargs))
+        except TypeError:
+            return bool(button_fn(label))
+    return False
 
 
 def safe_write(value: object) -> None:
@@ -158,6 +225,18 @@ def safe_audio(data, **kwargs) -> None:
     audio_fn = getattr(st, "audio", None)
     if callable(audio_fn):
         audio_fn(data, **kwargs)
+
+
+def safe_metric(label: str, value: object, **kwargs) -> None:
+    metric_fn = getattr(st, "metric", None)
+    if callable(metric_fn):
+        try:
+            metric_fn(label, value, **kwargs)
+            return
+        except TypeError:
+            metric_fn(label, value)
+            return
+    safe_markdown(f"**{label}:** {value}")
 
 
 def safe_audio_input(label: str, **kwargs):

--- a/streamlit_ui/layout.py
+++ b/streamlit_ui/layout.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from streamlit_ui.helpers import safe_markdown
+from streamlit_ui.helpers import (
+    safe_caption,
+    safe_columns,
+    safe_container,
+    safe_markdown,
+    safe_metric,
+)
 
 
 def render_section_header(title: str, subtitle: str = "") -> None:
@@ -13,6 +19,37 @@ def render_section_header(title: str, subtitle: str = "") -> None:
             f'<div class="ops-section-subtitle">{subtitle}</div>',
             unsafe_allow_html=True,
         )
+
+
+def render_workspace_topbar(
+    title: str,
+    subtitle: str = "",
+    *,
+    badge: str = "",
+    meta: Iterable[str] | None = None,
+) -> None:
+    """Render a restrained operational top bar for key workspaces."""
+    meta_items = [
+        f'<span class="ops-topbar-meta-item">{item}</span>'
+        for item in (str(value).strip() for value in (meta or []))
+        if item
+    ]
+    badge_markup = f'<span class="ops-badge ops-badge--neutral">{badge}</span>' if badge else ""
+    safe_markdown(
+        f"""
+        <div class="ops-workspace-topbar">
+          <div class="ops-topbar-row">
+            <div class="ops-topbar-copy">
+              {badge_markup}
+              <div class="ops-topbar-title">{title}</div>
+              <div class="ops-topbar-subtitle">{subtitle}</div>
+            </div>
+            <div class="ops-topbar-meta">{"".join(meta_items)}</div>
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def render_subsection(title: str, subtitle: str = "") -> None:
@@ -28,6 +65,45 @@ def render_subsection(title: str, subtitle: str = "") -> None:
     )
 
 
+def render_card_header(step: str, title: str, subtitle: str = "", *, badge: str = "") -> None:
+    """Render a compact workflow-card header."""
+    badge_markup = f'<span class="ops-badge ops-badge--quiet">{badge}</span>' if badge else ""
+    safe_markdown(
+        f"""
+        <div class="ops-card-header">
+          <div class="ops-card-header-row">
+            <div class="ops-card-copy">
+              <div class="ops-card-step">{step}</div>
+              <div class="ops-card-title">{title}</div>
+              <div class="ops-card-subtitle">{subtitle}</div>
+            </div>
+            {badge_markup}
+          </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_status_badges(items: Iterable[str | tuple[str, str]]) -> None:
+    """Render small status pills for workflow and readiness states."""
+    badges: list[str] = []
+    for item in items:
+        if isinstance(item, tuple):
+            text = str(item[0] or "").strip()
+            tone = str(item[1] or "neutral").strip().lower()
+        else:
+            text = str(item or "").strip()
+            tone = "neutral"
+        if not text:
+            continue
+        if tone not in {"neutral", "success", "warning", "danger"}:
+            tone = "neutral"
+        badges.append(f'<span class="ops-status-pill ops-status-pill--{tone}">{text}</span>')
+    if badges:
+        safe_markdown(f'<div class="ops-status-row">{"".join(badges)}</div>', unsafe_allow_html=True)
+
+
 def render_note(text: str) -> None:
     """Render a muted operational note."""
     if not text:
@@ -35,18 +111,26 @@ def render_note(text: str) -> None:
     safe_markdown(f'<div class="ops-note">{text}</div>', unsafe_allow_html=True)
 
 
-def render_kpi_strip(items: Iterable[tuple[str, object]]) -> None:
-    """Render a simple KPI strip for diagnostics or workflow counts."""
-    cards = []
-    for label, value in items:
-        cards.append(
-            f"""
-            <div class="ops-kpi">
-              <div class="ops-kpi-label">{label}</div>
-              <div class="ops-kpi-value">{value}</div>
-            </div>
-            """
-        )
-    if cards:
-        safe_markdown(f'<div class="ops-kpi-strip">{"".join(cards)}</div>', unsafe_allow_html=True)
+def render_kpi_strip(items: Iterable[tuple[str, object] | tuple[str, object, str]]) -> None:
+    """Render KPI cards using native Streamlit metrics."""
+    normalized_items: list[tuple[str, object, str]] = []
+    for item in items:
+        if not isinstance(item, tuple) or len(item) < 2:
+            continue
+        label = str(item[0] or "").strip()
+        if not label:
+            continue
+        value = item[1]
+        caption = str(item[2] or "").strip() if len(item) > 2 else ""
+        normalized_items.append((label, value, caption))
 
+    if not normalized_items:
+        return
+
+    columns = safe_columns(len(normalized_items), gap="small")
+    for column, (label, value, caption) in zip(columns, normalized_items):
+        with column:
+            with safe_container(border=True):
+                safe_metric(label, value)
+                if caption:
+                    safe_caption(caption)

--- a/streamlit_ui/reporting_workspace.py
+++ b/streamlit_ui/reporting_workspace.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
-
 import pandas as pd
 import streamlit as st
 
@@ -13,15 +11,29 @@ from services.media_service import generate_ai_photo_captions_for_reports
 from services.openai_client import default_openai_model, load_openai_api_key, openai_sdk_ready
 from sheets import CACHE_FILE, append_rows_to_sheet, get_sheet_data, get_unique_sites_and_dates, load_offline_cache
 from streamlit_ui.helpers import (
+    safe_button,
     safe_caption,
+    safe_checkbox,
     safe_columns,
+    safe_container,
     safe_data_editor,
+    safe_expander,
+    safe_file_uploader,
     safe_image,
     safe_markdown,
+    safe_multiselect,
+    safe_radio,
     safe_rerun,
+    safe_slider,
     safe_spinner,
 )
-from streamlit_ui.layout import render_kpi_strip, render_note, render_section_header, render_subsection
+from streamlit_ui.layout import (
+    render_card_header,
+    render_kpi_strip,
+    render_note,
+    render_status_badges,
+    render_workspace_topbar,
+)
 
 
 def load_sheet_context(*, get_sheet_data_fn=get_sheet_data, get_unique_sites_and_dates_fn=get_unique_sites_and_dates):
@@ -104,16 +116,92 @@ def fallback_caption_mapping_for_images(image_mapping: dict) -> dict[tuple[str, 
     return fallback
 
 
-def render_gallery_sidebar() -> dict[str, object]:
-    """Render restrained report output controls in the sidebar."""
-    st.sidebar.subheader("Report Output Settings")
-    img_width_mm = st.sidebar.slider("Gallery width (mm)", min_value=120, max_value=250, value=185, step=5)
-    img_height_mm = st.sidebar.slider("Wide photo height (mm)", min_value=70, max_value=180, value=120, step=5)
-    show_photo_placeholders = st.sidebar.checkbox("Show placeholders when photos are missing", value=False)
-    auto_caption_images = st.sidebar.checkbox("Generate AI photo captions", value=True)
-    add_border = st.sidebar.checkbox("Add border around gallery slots", value=False)
-    spacing_mm = st.sidebar.slider("Gap between photos (mm)", min_value=0, max_value=20, value=5, step=1)
-    st.sidebar.caption("Output settings affect the generated report files only.")
+def sanitize_multiselect_state(key: str, valid_options: list[str]) -> None:
+    """Remove legacy or invalid values from persisted multiselect state."""
+    current = st.session_state.get(key)
+    if not isinstance(current, list):
+        return
+    valid = {str(option or "").strip() for option in valid_options}
+    cleaned = [str(value or "").strip() for value in current if str(value or "").strip() in valid]
+    if cleaned != current:
+        st.session_state[key] = cleaned
+
+
+def selection_summary_text(selected_values: list[str], *, total_count: int, noun: str) -> str:
+    if not selected_values:
+        return f"{noun.title()}: All"
+    suffix = "" if len(selected_values) == 1 else "s"
+    return f"{noun.title()}: {len(selected_values)} selected {noun}{suffix}"
+
+
+def photo_group_statuses(image_group: list[bytes], captions: list[str]) -> list[tuple[str, str]]:
+    statuses: list[tuple[str, str]] = []
+    if image_group:
+        statuses.append(("Ready", "success"))
+        statuses.append((f"{len(image_group)} photo(s) attached", "success"))
+    else:
+        statuses.append(("No photos", "warning"))
+    if captions:
+        statuses.append(("Captions cached", "neutral"))
+    return statuses
+
+
+def photo_group_label(site: str, date: str, image_group: list[bytes], captions: list[str]) -> str:
+    label = f"{site} | {date}"
+    if image_group and captions:
+        return f"{label} · Ready · Captions cached"
+    if image_group:
+        return f"{label} · Photos attached"
+    return f"{label} · No photos"
+
+
+def count_attached_photo_groups(site_date_pairs: list[tuple[str, str]], image_mapping: dict) -> int:
+    attached = 0
+    for site, date in site_date_pairs:
+        images = (image_mapping or {}).get((site, date), [])
+        if images:
+            attached += 1
+    return attached
+
+
+def render_output_settings_panel() -> dict[str, object]:
+    """Render report output settings in a low-visibility expander."""
+    with safe_expander("Report output settings", expanded=False):
+        render_status_badges(
+            [
+                ("Export-only controls", "neutral"),
+                ("Gallery layout", "neutral"),
+                ("Captions and placeholders", "neutral"),
+            ]
+        )
+        dimensions_column, toggles_column = safe_columns((1.2, 1.0), gap="large")
+        with dimensions_column:
+            img_width_mm = safe_slider(
+                "Gallery width (mm)",
+                min_value=120,
+                max_value=250,
+                value=185,
+                step=5,
+            )
+            img_height_mm = safe_slider(
+                "Wide photo height (mm)",
+                min_value=70,
+                max_value=180,
+                value=120,
+                step=5,
+            )
+            spacing_mm = safe_slider(
+                "Gap between photos (mm)",
+                min_value=0,
+                max_value=20,
+                value=5,
+                step=1,
+            )
+        with toggles_column:
+            show_photo_placeholders = safe_checkbox("Show placeholders when photos are missing", value=False)
+            auto_caption_images = safe_checkbox("Generate AI photo captions", value=True)
+            add_border = safe_checkbox("Add border around gallery slots", value=False)
+            safe_caption("These settings affect generated report files only.")
     return {
         "img_width_mm": img_width_mm,
         "img_height_mm": img_height_mm,
@@ -135,9 +223,11 @@ def render_reporting_workspace(
     generate_reports_fn=generate_reports,
 ) -> None:
     """Render the main reporting workflow as the primary product path."""
-    render_section_header(
+    render_workspace_topbar(
         "1. Reporting Workspace",
         "Review daily rows from Google Sheets, attach site photos, and generate final report files.",
+        badge="Operational workspace",
+        meta=["Sheet review", "Photo tracking", "DOCX / ZIP export"],
     )
 
     data_rows, sites, data_error = load_sheet_context(
@@ -149,12 +239,10 @@ def render_reporting_workspace(
         record_runtime_issue("sheet_data", "Failed to load site data.", details=str(data_error))
         return
 
-    gallery_settings = render_gallery_sidebar()
-
     cache = load_offline_cache_fn()
     if cache and cache.get("rows"):
         render_note("Cached offline data is waiting to be synced back to Google Sheets.")
-        if st.button("Sync cached data to Google Sheet"):
+        if safe_button("Sync cached data to Google Sheet", type="secondary"):
             try:
                 append_rows_to_sheet_fn(cache.get("rows", []))
                 CACHE_FILE.unlink()
@@ -163,127 +251,239 @@ def render_reporting_workspace(
                 st.error(f"Sync failed: {exc}")
                 record_runtime_issue("sheet_sync", "Failed to sync cached data to Google Sheet.", details=str(exc))
 
-    render_subsection("Filters", "Select the reporting discipline, sites, and dates before review.")
-    discipline_column, selectors_column = safe_columns((0.9, 1.8), gap="large")
-    with discipline_column:
-        discipline = st.radio("Discipline", ["Civil", "Electrical"], key="discipline_radio")
-    with selectors_column:
-        sites_column, dates_column = safe_columns(2, gap="large")
-        site_options = ["All Sites"] + sites if sites else ["All Sites"]
-        with sites_column:
-            selected_sites_raw = st.multiselect("Sites", site_options, default=["All Sites"], key="sites_ms")
-        selected_sites = sites.copy() if "All Sites" in selected_sites_raw or not selected_sites_raw else selected_sites_raw
+    with safe_container(border=True):
+        render_card_header(
+            "Step 1",
+            "Filter & Scope",
+            "Set discipline and reporting scope without occupying the screen with default selection chips.",
+            badge="Command deck",
+        )
+        control_columns = safe_columns((1.0, 1.45, 1.45, 0.7), gap="small")
+        site_options = sites.copy()
+        sanitize_multiselect_state("sites_ms", site_options)
 
-        available_dates = sorted({row[0].strip() for row in data_rows if not selected_sites or row[1].strip() in selected_sites})
-        date_options = ["All Dates"] + available_dates if available_dates else ["All Dates"]
-        with dates_column:
-            selected_dates_raw = st.multiselect("Dates", date_options, default=["All Dates"], key="dates_ms")
-        selected_dates = available_dates if "All Dates" in selected_dates_raw or not selected_dates_raw else selected_dates_raw
+        with control_columns[0]:
+            discipline = safe_radio(
+                "Discipline",
+                ["Civil", "Electrical"],
+                key="discipline_radio",
+                horizontal=True,
+            )
+
+        with control_columns[1]:
+            selected_sites_raw = safe_multiselect(
+                "Sites",
+                site_options,
+                default=[],
+                key="sites_ms",
+                placeholder="All sites",
+            )
+
+        selected_sites = sites.copy() if not selected_sites_raw else list(selected_sites_raw)
+        available_dates = sorted(
+            {
+                row[0].strip()
+                for row in data_rows
+                if not selected_sites or row[1].strip() in selected_sites
+            }
+        )
+        sanitize_multiselect_state("dates_ms", available_dates)
+
+        with control_columns[2]:
+            selected_dates_raw = safe_multiselect(
+                "Dates",
+                available_dates,
+                default=[],
+                key="dates_ms",
+                placeholder="All dates",
+            )
+
+        with control_columns[3]:
+            reset_filters = safe_button(
+                "Reset filters",
+                key="reset_reporting_filters",
+                type="secondary",
+                use_container_width=True,
+            )
+
+        if reset_filters:
+            st.session_state.pop("sites_ms", None)
+            st.session_state.pop("dates_ms", None)
+            selected_sites_raw = []
+            selected_dates_raw = []
+            selected_sites = sites.copy()
+            available_dates = sorted({row[0].strip() for row in data_rows})
+            safe_rerun()
+
+        selected_dates = available_dates.copy() if not selected_dates_raw else list(selected_dates_raw)
+        render_status_badges(
+            [
+                (f"Discipline: {discipline}", "neutral"),
+                (selection_summary_text(list(selected_sites_raw), total_count=len(sites), noun="site"), "neutral"),
+                (selection_summary_text(list(selected_dates_raw), total_count=len(available_dates), noun="date"), "neutral"),
+            ]
+        )
 
     filtered_rows = [row for row in data_rows if row[1].strip() in selected_sites and row[0].strip() in selected_dates]
     site_date_pairs = sorted({(row[1].strip(), row[0].strip()) for row in filtered_rows})
+    image_mapping = st.session_state.get("images", {})
+    attached_photo_groups = count_attached_photo_groups(site_date_pairs, image_mapping)
+    missing_photo_groups = max(len(site_date_pairs) - attached_photo_groups, 0)
     render_kpi_strip(
         [
-            ("Rows in scope", len(filtered_rows)),
-            ("Sites", len({row[1].strip() for row in filtered_rows})),
-            ("Site/date sets", len(site_date_pairs)),
+            ("Rows in scope", len(filtered_rows), "Current rows after the active scope."),
+            ("Sites", len({row[1].strip() for row in filtered_rows}), "Unique sites represented in this export."),
+            ("Site/date sets", len(site_date_pairs), "Distinct report groups for upload and export."),
+            ("Photo groups ready", attached_photo_groups, "Site/date groups that already have attached photos."),
         ]
     )
 
-    render_subsection("Review Table", "Edit report content before generation. Date and Site_Name remain locked to preserve file mapping.")
-    df_preview = pd.DataFrame(filtered_rows, columns=REPORT_HEADERS)
-    st.dataframe(df_preview, width="stretch")
-    safe_caption("Locked fields in the editor: Date, Site_Name.")
-    review_df = safe_data_editor(
-        df_preview,
-        width="stretch",
-        hide_index=True,
-        disabled=["Date", "Site_Name"],
-        key="review_editor",
-    )
-    review_rows = normalized_review_rows(review_df) or [(row + [""] * len(REPORT_HEADERS))[: len(REPORT_HEADERS)] for row in filtered_rows]
+    with safe_container(border=True):
+        render_card_header(
+            "Step 2",
+            "Review Data",
+            "Review and edit report content before generation. Date and Site_Name remain locked to preserve file mapping.",
+        )
+        df_preview = pd.DataFrame(filtered_rows, columns=REPORT_HEADERS)
+        st.dataframe(df_preview, width="stretch")
+        safe_caption("Locked fields in the editor: Date, Site_Name.")
+        review_df = safe_data_editor(
+            df_preview,
+            width="stretch",
+            hide_index=True,
+            disabled=["Date", "Site_Name"],
+            key="review_editor",
+        )
+        review_rows = normalized_review_rows(review_df) or [
+            (row + [""] * len(REPORT_HEADERS))[: len(REPORT_HEADERS)]
+            for row in filtered_rows
+        ]
 
     structured_from_rows = rows_to_structured_data(review_rows)
     if st.session_state.get("_structured_origin") != "manual":
         st.session_state["structured_report_data"] = structured_from_rows
         st.session_state["_structured_origin"] = "rows"
 
-    render_subsection("Site Photo Uploads", "Attach photos by site and date. Existing AI captions remain visible when available.")
-    if not site_date_pairs:
-        safe_caption("No filtered rows are available for photo attachment.")
-    for site, date in site_date_pairs:
-        with st.expander(f"{site} | {date}", expanded=False):
-            files = st.file_uploader(
-                f"Upload images for {site} - {date}",
-                accept_multiple_files=True,
-                type=["png", "jpg", "jpeg", "webp"],
-                key=f"uploader_{site}_{date}",
+    with safe_container(border=True):
+        render_card_header(
+            "Step 3",
+            "Site Photo Uploads",
+            "Attach photos by site and date. Upload status and cached AI captions stay visible per group.",
+        )
+        if not site_date_pairs:
+            safe_caption("No filtered rows are available for photo attachment.")
+        for site, date in site_date_pairs:
+            normalized_key = (site.strip(), date.strip())
+            image_group = (st.session_state.get("images", {}) or {}).get(normalized_key, [])
+            cached_captions = (st.session_state.get(AI_IMAGE_CAPTIONS_KEY, {}) or {}).get(
+                f"{normalized_key[0]}|{normalized_key[1]}",
+                {},
             )
-            if files:
-                key = (site.strip(), date.strip())
-                st.session_state.setdefault("images", {})[key] = [f.read() for f in files]
-            image_group = (st.session_state.get("images", {}) or {}).get((site.strip(), date.strip()), [])
-            if image_group:
-                safe_image(image_group, width=220)
-            cached_captions = (st.session_state.get(AI_IMAGE_CAPTIONS_KEY, {}) or {}).get(f"{site.strip()}|{date.strip()}", {})
-            if isinstance(cached_captions, dict):
-                captions = cached_captions.get("captions", [])
-                if isinstance(captions, list) and captions:
+            captions = cached_captions.get("captions", []) if isinstance(cached_captions, dict) else []
+            captions = captions if isinstance(captions, list) else []
+
+            with safe_expander(
+                photo_group_label(site.strip(), date.strip(), image_group, captions),
+                expanded=False,
+            ):
+                render_status_badges(photo_group_statuses(image_group, captions))
+                files = safe_file_uploader(
+                    f"Upload images for {site} - {date}",
+                    accept_multiple_files=True,
+                    type=["png", "jpg", "jpeg", "webp"],
+                    key=f"uploader_{site}_{date}",
+                )
+                if files:
+                    st.session_state.setdefault("images", {})[normalized_key] = [f.read() for f in files]
+                    image_group = st.session_state["images"][normalized_key]
+                if image_group:
+                    safe_image(image_group, width=220)
+                if captions:
                     safe_caption("AI captions: " + " | ".join(str(caption or "").strip() for caption in captions))
 
-    render_subsection("Report Generation", "Generate the final ZIP after review and photo checks are complete.")
-    if st.button("Generate Reports"):
-        if not review_rows:
-            st.warning("No data is available for the selected sites and dates.")
-            return
+    with safe_container(border=True):
+        render_card_header(
+            "Step 4",
+            "Report Output",
+            "Review readiness, adjust low-frequency output settings only when needed, and generate the final report package.",
+            badge="Primary action",
+        )
+        gallery_settings = render_output_settings_panel()
+        caption_status = "AI captions on" if gallery_settings["auto_caption_images"] else "AI captions off"
+        render_status_badges(
+            [
+                (f"{len(review_rows)} row(s) ready", "neutral"),
+                (
+                    f"{attached_photo_groups}/{len(site_date_pairs)} photo groups attached" if site_date_pairs else "No photo groups in scope",
+                    "success" if attached_photo_groups or not site_date_pairs else "warning",
+                ),
+                (
+                    f"{missing_photo_groups} group(s) missing photos" if missing_photo_groups else "No missing photo groups",
+                    "warning" if missing_photo_groups else "success",
+                ),
+                (caption_status, "neutral"),
+            ]
+        )
+        safe_caption("Reports are generated as DOCX files packaged into one ZIP using the current scope and output settings.")
 
-        try:
-            image_mapping = st.session_state.get("images", {})
-            image_caption_mapping = None
-            if gallery_settings["auto_caption_images"] and image_mapping:
-                api_key = load_openai_api_key()
-                sdk_ready, sdk_error = openai_sdk_ready()
-                if api_key and sdk_ready:
-                    try:
-                        with safe_spinner("Generating AI photo captions..."):
-                            image_caption_mapping = generate_ai_photo_captions_for_reports(
-                                review_rows,
-                                image_mapping,
-                                api_key=api_key,
-                                model=default_openai_model(),
-                                discipline=discipline,
-                                persistent_guidance=active_guidance_text("captions", "converter"),
+        if safe_button("Generate Reports", type="primary", use_container_width=True):
+            if not review_rows:
+                st.warning("No data is available for the selected sites and dates.")
+                return
+
+            try:
+                image_mapping = st.session_state.get("images", {})
+                image_caption_mapping = None
+                if gallery_settings["auto_caption_images"] and image_mapping:
+                    api_key = load_openai_api_key()
+                    sdk_ready, sdk_error = openai_sdk_ready()
+                    if api_key and sdk_ready:
+                        try:
+                            with safe_spinner("Generating AI photo captions..."):
+                                image_caption_mapping = generate_ai_photo_captions_for_reports(
+                                    review_rows,
+                                    image_mapping,
+                                    api_key=api_key,
+                                    model=default_openai_model(),
+                                    discipline=discipline,
+                                    persistent_guidance=active_guidance_text("captions", "converter"),
+                                )
+                        except Exception as caption_error:
+                            image_caption_mapping = fallback_caption_mapping_for_images(image_mapping)
+                            st.warning("AI photo captions failed and were skipped. Report export will continue.")
+                            record_runtime_issue(
+                                "photo_captioning",
+                                "AI photo captions failed; report export continued with fallback captions.",
+                                details=str(caption_error),
                             )
-                    except Exception as caption_error:
-                        image_caption_mapping = fallback_caption_mapping_for_images(image_mapping)
-                        st.warning("AI photo captions failed and were skipped. Report export will continue.")
-                        record_runtime_issue(
-                            "photo_captioning",
-                            "AI photo captions failed; report export continued with fallback captions.",
-                            details=str(caption_error),
-                        )
-                elif not sdk_ready:
-                    st.warning(f"Photo captions skipped because the OpenAI SDK is unavailable. {sdk_error}")
-                else:
-                    st.warning("Photo captions skipped because no OpenAI API key is configured.")
+                    elif not sdk_ready:
+                        st.warning(f"Photo captions skipped because the OpenAI SDK is unavailable. {sdk_error}")
+                    else:
+                        st.warning("Photo captions skipped because no OpenAI API key is configured.")
 
-            zip_bytes = generate_reports_with_gallery_options(
-                review_rows,
-                image_mapping,
-                discipline,
-                int(gallery_settings["img_width_mm"]),
-                int(gallery_settings["img_height_mm"]),
-                int(gallery_settings["spacing_mm"]),
-                add_border=bool(gallery_settings["add_border"]),
-                show_photo_placeholders=bool(gallery_settings["show_photo_placeholders"]),
-                image_caption_mapping=image_caption_mapping,
-                generate_reports_fn=generate_reports_fn,
-            )
-        except Exception as exc:
-            st.error(f"Failed to generate reports: {exc}")
-            record_runtime_issue("report_generation", "Report generation failed.", details=str(exc))
-        else:
-            st.download_button("Download report ZIP", zip_bytes, "reports.zip")
+                zip_bytes = generate_reports_with_gallery_options(
+                    review_rows,
+                    image_mapping,
+                    discipline,
+                    int(gallery_settings["img_width_mm"]),
+                    int(gallery_settings["img_height_mm"]),
+                    int(gallery_settings["spacing_mm"]),
+                    add_border=bool(gallery_settings["add_border"]),
+                    show_photo_placeholders=bool(gallery_settings["show_photo_placeholders"]),
+                    image_caption_mapping=image_caption_mapping,
+                    generate_reports_fn=generate_reports_fn,
+                )
+            except Exception as exc:
+                st.error(f"Failed to generate reports: {exc}")
+                record_runtime_issue("report_generation", "Report generation failed.", details=str(exc))
+            else:
+                st.download_button(
+                    "Download report ZIP",
+                    zip_bytes,
+                    "reports.zip",
+                    type="primary",
+                    use_container_width=True,
+                )
 
     st.session_state["structured_report_data"] = normalize_structured_rows(rows_to_structured_data(review_rows))
     safe_markdown("---")

--- a/streamlit_ui/theme.py
+++ b/streamlit_ui/theme.py
@@ -1,98 +1,186 @@
 from __future__ import annotations
 
-import streamlit as st
-
 from streamlit_ui.helpers import safe_markdown
 
 
 def apply_professional_theme() -> None:
-    """Apply a restrained reporting-focused theme."""
+    """Apply a restrained enterprise theme for operational reporting workflows."""
     safe_markdown(
         """
         <style>
         :root {
-            --app-bg: #f4f6f8;
+            --app-bg: #f3f5f7;
             --panel-bg: #ffffff;
-            --panel-border: #d7dde5;
-            --ink: #17212b;
-            --muted: #5d6b79;
-            --accent: #24405a;
-            --accent-soft: #eef3f7;
-            --success-soft: #edf7f1;
-            --warning-soft: #fff6e8;
-            --danger-soft: #fff0ef;
+            --panel-bg-soft: #f8fafb;
+            --panel-border: #d7dfe7;
+            --panel-border-strong: #c4cfdb;
+            --ink: #15202b;
+            --muted: #66788a;
+            --accent: #1f4e6d;
+            --accent-soft: #eaf2f7;
+            --success-soft: #edf6ef;
+            --warning-soft: #fff7e8;
+            --danger-soft: #fff1ef;
+            --radius-sm: 10px;
+            --radius-md: 14px;
+            --radius-lg: 18px;
+            --shadow-soft: 0 10px 30px rgba(18, 32, 45, 0.05);
+            --shadow-card: 0 4px 16px rgba(18, 32, 45, 0.04);
         }
 
         html, body, [data-testid="stAppViewContainer"], .stApp {
             background: var(--app-bg);
             color: var(--ink);
+            font-family: "Aptos", "Segoe UI", sans-serif;
         }
 
         [data-testid="stHeader"] {
-            background: transparent;
+            background: rgba(243, 245, 247, 0.92);
+            border-bottom: 1px solid rgba(21, 32, 43, 0.05);
+            backdrop-filter: blur(6px);
         }
 
         .block-container {
-            padding-top: 1.4rem;
-            padding-bottom: 2.2rem;
-            max-width: 1320px;
+            max-width: 1240px;
+            padding-top: 1rem;
+            padding-bottom: 2.5rem;
         }
 
         [data-testid="stSidebar"] > div:first-child {
-            background: #eef2f5;
+            background: #f7f9fb;
             border-right: 1px solid var(--panel-border);
         }
 
-        div[data-testid="stVerticalBlock"] > div:has(> .ops-section-title) {
-            margin-top: 0;
-        }
-
-        .ops-page-header {
-            background: linear-gradient(180deg, #ffffff 0%, #f7f9fb 100%);
-            border: 1px solid var(--panel-border);
-            border-radius: 12px;
-            padding: 1.1rem 1.25rem;
-            margin-bottom: 1rem;
-        }
-
-        .ops-page-title {
-            font-size: 1.8rem;
-            font-weight: 700;
-            margin: 0 0 0.25rem 0;
+        h1, h2, h3, h4, h5, h6 {
             color: var(--ink);
             letter-spacing: -0.02em;
         }
 
+        p, label, span {
+            color: inherit;
+        }
+
+        .ops-page-header,
+        .ops-workspace-topbar {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow-soft);
+        }
+
+        .ops-page-header {
+            padding: 1rem 1.15rem 1.05rem 1.15rem;
+            margin-bottom: 1rem;
+        }
+
+        .ops-page-eyebrow {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.32rem 0.68rem;
+            border-radius: 999px;
+            background: var(--accent-soft);
+            color: var(--accent);
+            font-size: 0.74rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            margin-bottom: 0.65rem;
+        }
+
+        .ops-page-title {
+            font-size: 1.7rem;
+            font-weight: 700;
+            margin: 0 0 0.28rem 0;
+            color: var(--ink);
+        }
+
         .ops-page-subtitle {
+            max-width: 72ch;
             margin: 0;
             color: var(--muted);
-            font-size: 0.97rem;
+            font-size: 0.96rem;
             line-height: 1.55;
         }
 
+        .ops-workspace-topbar {
+            padding: 1rem 1.1rem;
+            margin: 0.2rem 0 0.9rem 0;
+        }
+
+        .ops-topbar-row,
+        .ops-card-header-row {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 0.9rem;
+            flex-wrap: wrap;
+        }
+
+        .ops-topbar-copy,
+        .ops-card-copy {
+            display: flex;
+            flex-direction: column;
+            gap: 0.3rem;
+            min-width: 0;
+        }
+
+        .ops-topbar-title {
+            font-size: 1.4rem;
+            font-weight: 700;
+            line-height: 1.15;
+            color: var(--ink);
+        }
+
+        .ops-topbar-subtitle {
+            color: var(--muted);
+            line-height: 1.5;
+            max-width: 70ch;
+            font-size: 0.95rem;
+        }
+
+        .ops-topbar-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.45rem;
+            justify-content: flex-end;
+        }
+
+        .ops-topbar-meta-item {
+            display: inline-flex;
+            align-items: center;
+            min-height: 30px;
+            padding: 0.35rem 0.72rem;
+            border-radius: 999px;
+            background: var(--panel-bg-soft);
+            border: 1px solid var(--panel-border);
+            color: var(--muted);
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+
         .ops-section-title {
-            font-size: 1.3rem;
+            font-size: 1.22rem;
             font-weight: 700;
             color: var(--ink);
-            margin: 1.4rem 0 0.15rem 0;
+            margin: 1.35rem 0 0.15rem 0;
         }
 
         .ops-section-subtitle {
             color: var(--muted);
-            margin: 0 0 0.9rem 0;
+            margin: 0 0 0.85rem 0;
             line-height: 1.5;
         }
 
         .ops-subsection {
             background: var(--panel-bg);
             border: 1px solid var(--panel-border);
-            border-radius: 12px;
-            padding: 0.9rem 1rem 1rem 1rem;
-            margin: 0.85rem 0;
+            border-radius: var(--radius-md);
+            padding: 0.85rem 0.95rem 0.95rem 0.95rem;
+            margin: 0.8rem 0;
         }
 
         .ops-subsection h4 {
-            margin: 0 0 0.25rem 0;
+            margin: 0 0 0.24rem 0;
             font-size: 1rem;
             color: var(--accent);
         }
@@ -104,61 +192,225 @@ def apply_professional_theme() -> None:
             font-size: 0.92rem;
         }
 
-        div[data-testid="stDataFrame"], div[data-testid="stTable"] {
-            border: 1px solid var(--panel-border);
-            border-radius: 12px;
-            background: #fff;
+        .ops-card-header {
+            margin-bottom: 0.85rem;
         }
 
-        .stButton > button {
-            border-radius: 8px;
-            border: 1px solid #aeb7c2;
-            background: #ffffff;
+        .ops-card-step {
+            color: var(--muted);
+            font-size: 0.76rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            font-weight: 700;
+        }
+
+        .ops-card-title {
+            font-size: 1.08rem;
+            font-weight: 700;
+            color: var(--ink);
+        }
+
+        .ops-card-subtitle {
+            color: var(--muted);
+            line-height: 1.5;
+            font-size: 0.92rem;
+            max-width: 72ch;
+        }
+
+        .ops-badge {
+            display: inline-flex;
+            align-items: center;
+            min-height: 30px;
+            padding: 0.34rem 0.72rem;
+            border-radius: 999px;
+            font-size: 0.74rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            white-space: nowrap;
+        }
+
+        .ops-badge--neutral {
+            background: var(--accent-soft);
+            color: var(--accent);
+        }
+
+        .ops-badge--quiet {
+            background: var(--panel-bg-soft);
+            border: 1px solid var(--panel-border);
+            color: var(--muted);
+        }
+
+        .ops-status-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.45rem;
+            margin: 0.15rem 0 0.85rem 0;
+        }
+
+        .ops-status-pill {
+            display: inline-flex;
+            align-items: center;
+            min-height: 30px;
+            padding: 0.35rem 0.72rem;
+            border-radius: 999px;
+            border: 1px solid transparent;
+            font-size: 0.8rem;
+            font-weight: 600;
+        }
+
+        .ops-status-pill--neutral {
+            background: var(--panel-bg-soft);
+            border-color: var(--panel-border);
+            color: var(--muted);
+        }
+
+        .ops-status-pill--success {
+            background: var(--success-soft);
+            color: #295a3b;
+        }
+
+        .ops-status-pill--warning {
+            background: var(--warning-soft);
+            color: #8a5a12;
+        }
+
+        .ops-status-pill--danger {
+            background: var(--danger-soft);
+            color: #9b3a31;
+        }
+
+        .ops-note {
+            background: var(--accent-soft);
+            border: 1px solid rgba(31, 78, 109, 0.12);
+            border-left: 4px solid var(--accent);
+            border-radius: var(--radius-md);
+            padding: 0.78rem 0.9rem;
+            color: var(--ink);
+            margin: 0.75rem 0;
+            font-size: 0.92rem;
+        }
+
+        div[data-testid="stVerticalBlockBorderWrapper"] {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow-card);
+        }
+
+        div[data-testid="stMetric"] {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-md);
+            padding: 0.9rem 1rem;
+            box-shadow: var(--shadow-card);
+        }
+
+        div[data-testid="stMetricLabel"] {
+            color: var(--muted);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.74rem;
+            font-weight: 700;
+        }
+
+        div[data-testid="stMetricValue"] {
+            color: var(--ink);
+            font-size: 1.55rem;
+            font-weight: 700;
+        }
+
+        div[data-testid="stDataFrame"],
+        div[data-testid="stTable"] {
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-md);
+            background: var(--panel-bg);
+        }
+
+        div[data-baseweb="select"] > div,
+        div[data-testid="stTextInputRootElement"] > div,
+        div[data-testid="stTextAreaRootElement"] > div,
+        div[data-testid="stNumberInput"] > div {
+            border-radius: 12px;
+            border-color: var(--panel-border);
+            background: var(--panel-bg);
+            box-shadow: none;
+        }
+
+        div[data-testid="stMultiSelect"] label,
+        div[data-testid="stRadio"] label,
+        div[data-testid="stSlider"] label,
+        div[data-testid="stCheckbox"] label {
+            font-size: 0.84rem;
+            font-weight: 600;
+            color: var(--muted);
+        }
+
+        div[role="radiogroup"] {
+            gap: 0.55rem;
+        }
+
+        div[role="radiogroup"] > label {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: 999px;
+            padding: 0.3rem 0.72rem;
+        }
+
+        details {
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-md);
+        }
+
+        summary {
+            padding-top: 0.15rem;
+            padding-bottom: 0.15rem;
+        }
+
+        .stButton > button,
+        .stDownloadButton > button {
+            border-radius: 12px;
+            min-height: 2.85rem;
+            border: 1px solid var(--panel-border-strong);
+            background: var(--panel-bg);
             color: var(--ink);
             font-weight: 600;
             box-shadow: none;
         }
 
-        .stDownloadButton > button {
-            border-radius: 8px;
+        .stButton > button:hover,
+        .stDownloadButton > button:hover {
+            border-color: var(--accent);
+            color: var(--accent);
         }
 
-        .ops-note {
-            background: var(--accent-soft);
-            border-left: 4px solid var(--accent);
-            border-radius: 8px;
-            padding: 0.7rem 0.85rem;
-            color: var(--ink);
-            margin: 0.75rem 0;
-            font-size: 0.93rem;
+        .stButton > button[kind="primary"],
+        .stDownloadButton > button[kind="primary"] {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #ffffff;
         }
 
-        .ops-kpi-strip {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-            gap: 0.75rem;
-            margin: 0.85rem 0 1rem 0;
+        .stButton > button[kind="primary"]:hover,
+        .stDownloadButton > button[kind="primary"]:hover {
+            background: #173f57;
+            border-color: #173f57;
+            color: #ffffff;
         }
 
-        .ops-kpi {
-            background: #fff;
-            border: 1px solid var(--panel-border);
-            border-radius: 10px;
-            padding: 0.75rem 0.85rem;
-        }
+        @media (max-width: 900px) {
+            .block-container {
+                padding-top: 0.8rem;
+            }
 
-        .ops-kpi-label {
-            color: var(--muted);
-            font-size: 0.8rem;
-            margin-bottom: 0.2rem;
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-        }
+            .ops-page-title {
+                font-size: 1.45rem;
+            }
 
-        .ops-kpi-value {
-            color: var(--ink);
-            font-size: 1.25rem;
-            font-weight: 700;
+            .ops-topbar-title {
+                font-size: 1.18rem;
+            }
         }
         </style>
         """,
@@ -171,13 +423,12 @@ def render_app_header() -> None:
     safe_markdown(
         """
         <div class="ops-page-header">
+          <div class="ops-page-eyebrow">Engineering Operations</div>
           <div class="ops-page-title">IBC Reporting Platform</div>
           <p class="ops-page-subtitle">
-            Daily site reporting, contractor conversion, report generation, and operational diagnostics.
-            AI features are available where they support the workflow, but the reporting process remains the primary product path.
+            Daily site reporting, consultant review, photo tracking, and final report export in one operational workspace.
           </p>
         </div>
         """,
         unsafe_allow_html=True,
     )
-

--- a/tests/test_reporting_workspace.py
+++ b/tests/test_reporting_workspace.py
@@ -1,51 +1,70 @@
-import types
+import pandas as pd
 
+from streamlit_ui import helpers
 from streamlit_ui import reporting_workspace
 
 
-class _Spinner:
+class _Context:
     def __enter__(self):
-        return None
+        return self
 
     def __exit__(self, exc_type, exc, tb):
         return False
 
 
-class _SidebarStub:
-    def subheader(self, *_, **__):
-        return None
-
-    def slider(self, *_, value=None, **__):
-        return value
-
-    def checkbox(self, *_, value=False, **__):
-        return value
-
-    def caption(self, *_, **__):
-        return None
-
-
 class _StreamlitStub:
     def __init__(self):
         self.session_state = {"images": {("Site A", "2026-04-18"): [b"img-1", b"img-2"]}}
-        self.sidebar = _SidebarStub()
         self.warning_messages = []
         self.download_args = None
+        self.multiselect_calls = []
+        self.metric_calls = []
+        self.dataframe_capture = None
+        self.button_states = {
+            "Sync cached data to Google Sheet": False,
+            "Reset filters": False,
+            "Generate Reports": True,
+        }
 
-    def radio(self, _label, options, **__):
-        return options[0]
+    def container(self, *_, **__):
+        return _Context()
 
-    def multiselect(self, _label, _options, default, **__):
-        return default
+    def columns(self, spec, *_, **__):
+        if isinstance(spec, int):
+            count = spec
+        else:
+            count = len(spec)
+        return tuple(_Context() for _ in range(count))
 
-    def dataframe(self, *_, **__):
+    def radio(self, _label, options, index=0, **__):
+        return options[index]
+
+    def multiselect(self, label, options, default=None, **kwargs):
+        self.multiselect_calls.append(
+            {
+                "label": label,
+                "options": list(options),
+                "default": list(default or []),
+                "placeholder": kwargs.get("placeholder"),
+            }
+        )
+        return list(default or [])
+
+    def slider(self, _label, min_value=None, max_value=None, value=None, step=None, **__):
+        return value
+
+    def checkbox(self, _label, value=False, **__):
+        return value
+
+    def dataframe(self, df, *_, **__):
+        self.dataframe_capture = df.copy()
         return None
 
     def file_uploader(self, *_, **__):
         return []
 
     def button(self, label, *_, **__):
-        return label == "Generate Reports"
+        return self.button_states.get(label, False)
 
     def warning(self, message, *_, **__):
         self.warning_messages.append(message)
@@ -56,13 +75,74 @@ class _StreamlitStub:
         return None
 
     def expander(self, *_args, **_kwargs):
-        return _Spinner()
+        return _Context()
 
     def error(self, *_, **__):
         return None
 
+    def success(self, *_, **__):
+        return None
+
     def data_editor(self, df, *_, **__):
         return df
+
+    def metric(self, label, value, **__):
+        self.metric_calls.append((label, value))
+        return None
+
+    def caption(self, *_, **__):
+        return None
+
+    def markdown(self, *_, **__):
+        return None
+
+
+def _patch_layout(monkeypatch):
+    monkeypatch.setattr(helpers, "st", reporting_workspace.st)
+    monkeypatch.setattr(reporting_workspace, "render_workspace_topbar", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_card_header", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_kpi_strip", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_note", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_status_badges", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "safe_image", lambda *_, **__: None)
+
+
+def test_render_reporting_workspace_uses_empty_filter_defaults_and_preserves_all_scope(monkeypatch):
+    st_stub = _StreamlitStub()
+    st_stub.button_states["Generate Reports"] = False
+
+    monkeypatch.setattr(reporting_workspace, "st", st_stub)
+    _patch_layout(monkeypatch)
+
+    reporting_workspace.render_reporting_workspace(
+        record_runtime_issue=lambda *_, **__: None,
+        active_guidance_text=lambda *_args: "",
+        get_sheet_data_fn=lambda: [
+            ["header"],
+            ["2026-04-18", "Site A"] + [""] * 12,
+            ["2026-04-19", "Site B"] + [""] * 12,
+        ],
+        get_unique_sites_and_dates_fn=lambda rows: (["Site A", "Site B"], ["2026-04-18", "2026-04-19"]),
+        load_offline_cache_fn=lambda: {},
+        append_rows_to_sheet_fn=lambda *_args, **_kwargs: None,
+        generate_reports_fn=lambda *_args, **_kwargs: b"zip-bytes",
+    )
+
+    sites_call = next(call for call in st_stub.multiselect_calls if call["label"] == "Sites")
+    dates_call = next(call for call in st_stub.multiselect_calls if call["label"] == "Dates")
+
+    assert sites_call["options"] == ["Site A", "Site B"]
+    assert sites_call["default"] == []
+    assert sites_call["placeholder"] == "All sites"
+    assert "All Sites" not in sites_call["options"]
+
+    assert dates_call["options"] == ["2026-04-18", "2026-04-19"]
+    assert dates_call["default"] == []
+    assert dates_call["placeholder"] == "All dates"
+    assert "All Dates" not in dates_call["options"]
+
+    assert isinstance(st_stub.dataframe_capture, pd.DataFrame)
+    assert len(st_stub.dataframe_capture) == 2
 
 
 def test_render_reporting_workspace_caption_failure_uses_fallback_and_generates_zip(monkeypatch):
@@ -71,16 +151,8 @@ def test_render_reporting_workspace_caption_failure_uses_fallback_and_generates_
     captured_kwargs = {}
 
     monkeypatch.setattr(reporting_workspace, "st", st_stub)
-    monkeypatch.setattr(reporting_workspace, "render_section_header", lambda *_, **__: None)
-    monkeypatch.setattr(reporting_workspace, "render_subsection", lambda *_, **__: None)
-    monkeypatch.setattr(reporting_workspace, "render_kpi_strip", lambda *_, **__: None)
-    monkeypatch.setattr(reporting_workspace, "render_note", lambda *_, **__: None)
-    monkeypatch.setattr(reporting_workspace, "safe_columns", lambda *_, **__: (_Spinner(), _Spinner()))
-    monkeypatch.setattr(reporting_workspace, "safe_data_editor", lambda df, **__: df)
-    monkeypatch.setattr(reporting_workspace, "safe_caption", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(reporting_workspace, "safe_image", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(reporting_workspace, "safe_markdown", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(reporting_workspace, "safe_spinner", lambda *_args, **_kwargs: _Spinner())
+    _patch_layout(monkeypatch)
+    monkeypatch.setattr(reporting_workspace, "safe_spinner", lambda *_args, **_kwargs: _Context())
     monkeypatch.setattr(reporting_workspace, "openai_sdk_ready", lambda: (True, ""))
     monkeypatch.setattr(reporting_workspace, "load_openai_api_key", lambda: "key")
     monkeypatch.setattr(reporting_workspace, "default_openai_model", lambda: "gpt-4o-mini")


### PR DESCRIPTION
## Summary
- redesign the reporting workspace into a more compact, premium operational layout
- remove default `All Sites` / `All Dates` selected chips and preserve empty-selection = all behavior
- move low-frequency output controls into an in-section expander and improve KPI, upload, and output presentation

## Scope guardrails
- UI and presentation only
- no report generation, sheet logic, business logic, OpenAI workflow, or schema behavior changes

## Validation
- `pytest`