### PR TITLE
Polish reporting workspace UI and add optional live updates bar

### DIFF
--- a/streamlit_ui/helpers.py
+++ b/streamlit_ui/helpers.py
@@ -57,6 +57,19 @@ def safe_checkbox(label: str, *, value=False, key=None):
     return value
 
 
+def safe_toggle(label: str, *, value=False, key=None, **kwargs):
+    toggle_fn = getattr(st, "toggle", None)
+    if callable(toggle_fn):
+        try:
+            return toggle_fn(label, value=value, key=key, **kwargs)
+        except TypeError:
+            try:
+                return toggle_fn(label, value=value, key=key)
+            except TypeError:
+                return toggle_fn(label)
+    return safe_checkbox(label, value=value, key=key)
+
+
 def safe_caption(text: str) -> None:
     caption_fn = getattr(st, "caption", None)
     if callable(caption_fn):

--- a/streamlit_ui/news_bar.py
+++ b/streamlit_ui/news_bar.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import html
+import json
+import os
+import time
+import urllib.request
+import xml.etree.ElementTree as ET
+
+import streamlit as st
+
+from streamlit_ui.helpers import (
+    safe_columns,
+    safe_container,
+    safe_markdown,
+    safe_toggle,
+)
+
+DEFAULT_LIVE_UPDATE_TOPICS = ("infrastructure", "energy", "engineering", "weather", "safety")
+LIVE_UPDATES_TOGGLE_KEY = "reporting_show_live_updates"
+LIVE_UPDATES_CACHE_KEY = "_reporting_live_updates_cache"
+
+
+def _streamlit_secret(name: str, default: str = "") -> str:
+    try:
+        return str(st.secrets.get(name, default) or "").strip()
+    except Exception:
+        return str(default or "").strip()
+
+
+def _env_or_secret(name: str, default: str = "") -> str:
+    value = os.environ.get(name, "").strip()
+    if value:
+        return value
+    return _streamlit_secret(name, default)
+
+
+def _bool_setting(name: str, default: bool = False) -> bool:
+    value = _env_or_secret(name, "")
+    if not value:
+        return bool(default)
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _float_setting(name: str, default: float) -> float:
+    value = _env_or_secret(name, "")
+    if not value:
+        return float(default)
+    try:
+        return max(0.5, float(value))
+    except ValueError:
+        return float(default)
+
+
+def _int_setting(name: str, default: int) -> int:
+    value = _env_or_secret(name, "")
+    if not value:
+        return int(default)
+    try:
+        return max(1, int(value))
+    except ValueError:
+        return int(default)
+
+
+def parse_updates_items(value: object) -> list[dict[str, str]]:
+    """Normalize static update configuration into title/context dictionaries."""
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        if raw.startswith("["):
+            try:
+                return parse_updates_items(json.loads(raw))
+            except json.JSONDecodeError:
+                pass
+        pieces = [segment.strip() for segment in raw.replace("|", "\n").splitlines()]
+        return [{"title": item, "context": ""} for item in pieces if item]
+
+    normalized: list[dict[str, str]] = []
+    if not isinstance(value, list):
+        return normalized
+
+    for item in value:
+        if isinstance(item, str):
+            title = item.strip()
+            if title:
+                normalized.append({"title": title, "context": ""})
+            continue
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title", "") or "").strip()
+        if not title:
+            continue
+        context = str(item.get("context", "") or item.get("source", "") or item.get("topic", "") or "").strip()
+        normalized.append({"title": title, "context": context})
+    return normalized
+
+
+def load_live_updates_config() -> dict[str, object]:
+    """Read optional live-updates configuration from env or Streamlit secrets."""
+    static_items = parse_updates_items(_env_or_secret("REPORTING_LIVE_UPDATES_ITEMS", ""))
+    topics_raw = _env_or_secret("REPORTING_LIVE_UPDATES_TOPICS", "")
+    if topics_raw:
+        topics = tuple(topic.strip().lower() for topic in topics_raw.split(",") if topic.strip())
+    else:
+        topics = DEFAULT_LIVE_UPDATE_TOPICS
+
+    return {
+        "label": _env_or_secret("REPORTING_LIVE_UPDATES_LABEL", "Live updates") or "Live updates",
+        "feed_url": _env_or_secret("REPORTING_LIVE_UPDATES_FEED_URL", ""),
+        "topics": tuple(topics),
+        "timeout_seconds": _float_setting("REPORTING_LIVE_UPDATES_TIMEOUT_SECONDS", 2.0),
+        "cache_ttl_seconds": _int_setting("REPORTING_LIVE_UPDATES_CACHE_TTL_SECONDS", 300),
+        "max_items": _int_setting("REPORTING_LIVE_UPDATES_MAX_ITEMS", 5),
+        "enabled_by_default": _bool_setting("REPORTING_LIVE_UPDATES_ENABLED_BY_DEFAULT", False),
+        "static_items": static_items,
+    }
+
+
+def _local_name(tag: object) -> str:
+    value = str(tag or "")
+    return value.rsplit("}", 1)[-1].lower()
+
+
+def _first_child_text(node: ET.Element, allowed_names: tuple[str, ...]) -> str:
+    for child in list(node):
+        if _local_name(child.tag) not in allowed_names:
+            continue
+        text = "".join(child.itertext()).strip()
+        if text:
+            return " ".join(text.split())
+    return ""
+
+
+def _entry_link(node: ET.Element) -> str:
+    for child in list(node):
+        if _local_name(child.tag) != "link":
+            continue
+        href = str(child.attrib.get("href", "") or "").strip()
+        if href:
+            return href
+        text = "".join(child.itertext()).strip()
+        if text:
+            return text
+    return ""
+
+
+def _entry_categories(node: ET.Element) -> list[str]:
+    categories: list[str] = []
+    for child in list(node):
+        if _local_name(child.tag) != "category":
+            continue
+        term = str(child.attrib.get("term", "") or "").strip()
+        if term:
+            categories.append(term)
+            continue
+        text = "".join(child.itertext()).strip()
+        if text:
+            categories.append(text)
+    return categories
+
+
+def _entry_matches_topics(title: str, summary: str, categories: list[str], topics: tuple[str, ...]) -> bool:
+    if not topics:
+        return True
+    searchable = " ".join([title, summary, " ".join(categories)]).lower()
+    return any(topic in searchable for topic in topics)
+
+
+def fetch_feed_updates(feed_url: str, *, topics: tuple[str, ...], timeout_seconds: float, max_items: int) -> list[dict[str, str]]:
+    """Fetch a small set of RSS or Atom items and filter them to sector-relevant topics."""
+    request = urllib.request.Request(
+        feed_url,
+        headers={"User-Agent": "IBCReportingPlatform/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        payload = response.read()
+
+    root = ET.fromstring(payload)
+    items: list[dict[str, str]] = []
+    for node in root.iter():
+        if _local_name(node.tag) not in {"item", "entry"}:
+            continue
+        title = _first_child_text(node, ("title",))
+        summary = _first_child_text(node, ("description", "summary", "content"))
+        categories = _entry_categories(node)
+        if not title or not _entry_matches_topics(title, summary, categories, topics):
+            continue
+        context = categories[0] if categories else ""
+        items.append(
+            {
+                "title": title,
+                "context": context,
+                "link": _entry_link(node),
+            }
+        )
+        if len(items) >= max_items:
+            break
+    return items
+
+
+def load_live_updates_items(config: dict[str, object]) -> list[dict[str, str]]:
+    """Return live updates from static config or an optional feed."""
+    static_items = parse_updates_items(config.get("static_items", []))
+    if static_items:
+        return static_items[: int(config.get("max_items", 5) or 5)]
+
+    feed_url = str(config.get("feed_url", "") or "").strip()
+    if not feed_url:
+        return []
+
+    cache_key = "|".join(
+        [
+            feed_url,
+            ",".join(tuple(config.get("topics", DEFAULT_LIVE_UPDATE_TOPICS))),
+            str(int(config.get("max_items", 5) or 5)),
+        ]
+    )
+    cache = st.session_state.setdefault(LIVE_UPDATES_CACHE_KEY, {})
+    if isinstance(cache, dict):
+        cached = cache.get(cache_key, {})
+        loaded_at = float(cached.get("loaded_at", 0) or 0) if isinstance(cached, dict) else 0
+        cached_items = cached.get("items", []) if isinstance(cached, dict) else []
+        if (
+            isinstance(cached_items, list)
+            and cached_items
+            and (time.time() - loaded_at) < int(config.get("cache_ttl_seconds", 300) or 300)
+        ):
+            return cached_items
+
+    try:
+        items = fetch_feed_updates(
+            feed_url,
+            topics=tuple(config.get("topics", DEFAULT_LIVE_UPDATE_TOPICS)),
+            timeout_seconds=float(config.get("timeout_seconds", 2.0) or 2.0),
+            max_items=int(config.get("max_items", 5) or 5),
+        )
+    except Exception:
+        return []
+    if isinstance(cache, dict):
+        cache[cache_key] = {"loaded_at": time.time(), "items": items}
+        st.session_state[LIVE_UPDATES_CACHE_KEY] = cache
+    return items
+
+
+def render_live_updates_shell() -> None:
+    """Render an optional, visually secondary live-updates companion bar."""
+    config = load_live_updates_config()
+    toggle_default = bool(st.session_state.get(LIVE_UPDATES_TOGGLE_KEY, config.get("enabled_by_default", False)))
+    with safe_container(border=False):
+        info_column, toggle_column = safe_columns((1.6, 0.7), gap="small")
+        with info_column:
+            safe_markdown(
+                """
+                <div class="ops-live-shell">
+                  <div class="ops-live-shell-label">Sector updates</div>
+                  <div class="ops-live-shell-text">
+                    Optional companion updates for infrastructure, energy, engineering, weather, and safety.
+                  </div>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+        with toggle_column:
+            show_updates = safe_toggle(
+                "Show live updates",
+                value=toggle_default,
+                key=LIVE_UPDATES_TOGGLE_KEY,
+                help="Display a lightweight sector-focused updates strip without affecting reporting workflows.",
+            )
+
+    if not show_updates:
+        return
+
+    label = html.escape(str(config.get("label", "Live updates") or "Live updates"))
+    items = load_live_updates_items(config)
+    if not items:
+        safe_markdown(
+            f"""
+            <div class="ops-live-bar ops-live-bar--quiet">
+              <span class="ops-live-bar-label">{label}</span>
+              <span class="ops-live-bar-empty">News unavailable</span>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        return
+
+    item_markup: list[str] = []
+    for item in items:
+        title = html.escape(str(item.get("title", "") or "").strip())
+        if not title:
+            continue
+        context = html.escape(str(item.get("context", "") or "").strip())
+        context_markup = f'<span class="ops-live-bar-context">{context}</span>' if context else ""
+        item_markup.append(
+            f"""
+            <span class="ops-live-bar-item">
+              <span class="ops-live-bar-title">{title}</span>
+              {context_markup}
+            </span>
+            """
+        )
+
+    if not item_markup:
+        safe_markdown(
+            f"""
+            <div class="ops-live-bar ops-live-bar--quiet">
+              <span class="ops-live-bar-label">{label}</span>
+              <span class="ops-live-bar-empty">News unavailable</span>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        return
+
+    safe_markdown(
+        f"""
+        <div class="ops-live-bar">
+          <span class="ops-live-bar-label">{label}</span>
+          <div class="ops-live-bar-track">{"".join(item_markup)}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/streamlit_ui/reporting_workspace.py
+++ b/streamlit_ui/reporting_workspace.py
@@ -34,6 +34,7 @@ from streamlit_ui.layout import (
     render_status_badges,
     render_workspace_topbar,
 )
+from streamlit_ui.news_bar import render_live_updates_shell
 
 
 def load_sheet_context(*, get_sheet_data_fn=get_sheet_data, get_unique_sites_and_dates_fn=get_unique_sites_and_dates):
@@ -129,7 +130,7 @@ def sanitize_multiselect_state(key: str, valid_options: list[str]) -> None:
 
 def selection_summary_text(selected_values: list[str], *, total_count: int, noun: str) -> str:
     if not selected_values:
-        return f"{noun.title()}: All"
+        return f"{noun.title()}: All {total_count}"
     suffix = "" if len(selected_values) == 1 else "s"
     return f"{noun.title()}: {len(selected_values)} selected {noun}{suffix}"
 
@@ -162,6 +163,16 @@ def count_attached_photo_groups(site_date_pairs: list[tuple[str, str]], image_ma
         if images:
             attached += 1
     return attached
+
+
+def photo_group_display_label(site: str, date: str, image_group: list[bytes], captions: list[str]) -> str:
+    """Return an ASCII-only upload label for photo group expanders."""
+    label = f"{site} | {date}"
+    if image_group and captions:
+        return f"{label} - Ready - Captions cached"
+    if image_group:
+        return f"{label} - Photos attached"
+    return f"{label} - No photos"
 
 
 def render_output_settings_panel() -> dict[str, object]:
@@ -229,6 +240,7 @@ def render_reporting_workspace(
         badge="Operational workspace",
         meta=["Sheet review", "Photo tracking", "DOCX / ZIP export"],
     )
+    render_live_updates_shell()
 
     data_rows, sites, data_error = load_sheet_context(
         get_sheet_data_fn=get_sheet_data_fn,
@@ -335,6 +347,7 @@ def render_reporting_workspace(
             ("Sites", len({row[1].strip() for row in filtered_rows}), "Unique sites represented in this export."),
             ("Site/date sets", len(site_date_pairs), "Distinct report groups for upload and export."),
             ("Photo groups ready", attached_photo_groups, "Site/date groups that already have attached photos."),
+            ("Missing photo groups", missing_photo_groups, "Groups that still need photo attachments before export."),
         ]
     )
 
@@ -383,7 +396,7 @@ def render_reporting_workspace(
             captions = captions if isinstance(captions, list) else []
 
             with safe_expander(
-                photo_group_label(site.strip(), date.strip(), image_group, captions),
+                photo_group_display_label(site.strip(), date.strip(), image_group, captions),
                 expanded=False,
             ):
                 render_status_badges(photo_group_statuses(image_group, captions))

--- a/streamlit_ui/theme.py
+++ b/streamlit_ui/theme.py
@@ -69,8 +69,8 @@ def apply_professional_theme() -> None:
         }
 
         .ops-page-header {
-            padding: 1rem 1.15rem 1.05rem 1.15rem;
-            margin-bottom: 1rem;
+            padding: 1rem 1.15rem 1.08rem 1.15rem;
+            margin-bottom: 0.9rem;
         }
 
         .ops-page-eyebrow {
@@ -102,9 +102,29 @@ def apply_professional_theme() -> None:
             line-height: 1.55;
         }
 
+        .ops-page-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.48rem;
+            margin-top: 0.8rem;
+        }
+
+        .ops-page-meta-item {
+            display: inline-flex;
+            align-items: center;
+            min-height: 30px;
+            padding: 0.34rem 0.72rem;
+            border-radius: 999px;
+            background: var(--panel-bg-soft);
+            border: 1px solid var(--panel-border);
+            color: var(--muted);
+            font-size: 0.79rem;
+            font-weight: 600;
+        }
+
         .ops-workspace-topbar {
             padding: 1rem 1.1rem;
-            margin: 0.2rem 0 0.9rem 0;
+            margin: 0.2rem 0 0.55rem 0;
         }
 
         .ops-topbar-row,
@@ -291,6 +311,104 @@ def apply_professional_theme() -> None:
             font-size: 0.92rem;
         }
 
+        .ops-live-shell {
+            padding: 0.15rem 0 0.2rem 0;
+        }
+
+        .ops-live-shell-label {
+            color: var(--ink);
+            font-size: 0.82rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            margin-bottom: 0.15rem;
+        }
+
+        .ops-live-shell-text {
+            color: var(--muted);
+            font-size: 0.9rem;
+            line-height: 1.45;
+        }
+
+        .ops-live-bar {
+            display: flex;
+            align-items: center;
+            gap: 0.7rem;
+            padding: 0.65rem 0.88rem;
+            margin: 0.2rem 0 0.95rem 0;
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-card);
+            overflow: hidden;
+        }
+
+        .ops-live-bar--quiet {
+            background: var(--panel-bg-soft);
+        }
+
+        .ops-live-bar-label {
+            display: inline-flex;
+            align-items: center;
+            min-height: 28px;
+            padding: 0.28rem 0.62rem;
+            border-radius: 999px;
+            background: var(--accent-soft);
+            color: var(--accent);
+            font-size: 0.74rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            white-space: nowrap;
+            flex: 0 0 auto;
+        }
+
+        .ops-live-bar-track {
+            display: flex;
+            flex-wrap: nowrap;
+            gap: 0.6rem;
+            align-items: stretch;
+            min-width: 0;
+            overflow-x: auto;
+            scrollbar-width: none;
+        }
+
+        .ops-live-bar-track::-webkit-scrollbar {
+            display: none;
+        }
+
+        .ops-live-bar-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            min-height: 34px;
+            padding: 0.34rem 0.68rem;
+            border-radius: 999px;
+            background: var(--panel-bg-soft);
+            border: 1px solid var(--panel-border);
+            white-space: nowrap;
+            flex: 0 0 auto;
+        }
+
+        .ops-live-bar-title {
+            color: var(--ink);
+            font-size: 0.88rem;
+            font-weight: 600;
+        }
+
+        .ops-live-bar-context {
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        .ops-live-bar-empty {
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
         div[data-testid="stVerticalBlockBorderWrapper"] {
             background: var(--panel-bg);
             border: 1px solid var(--panel-border);
@@ -340,10 +458,16 @@ def apply_professional_theme() -> None:
         div[data-testid="stMultiSelect"] label,
         div[data-testid="stRadio"] label,
         div[data-testid="stSlider"] label,
-        div[data-testid="stCheckbox"] label {
+        div[data-testid="stCheckbox"] label,
+        div[data-testid="stToggle"] label {
             font-size: 0.84rem;
             font-weight: 600;
             color: var(--muted);
+        }
+
+        div[data-testid="stToggle"] {
+            display: flex;
+            justify-content: flex-end;
         }
 
         div[role="radiogroup"] {
@@ -428,6 +552,11 @@ def render_app_header() -> None:
           <p class="ops-page-subtitle">
             Daily site reporting, consultant review, photo tracking, and final report export in one operational workspace.
           </p>
+          <div class="ops-page-meta">
+            <span class="ops-page-meta-item">Reporting shell</span>
+            <span class="ops-page-meta-item">Operational controls</span>
+            <span class="ops-page-meta-item">Live updates optional</span>
+          </div>
         </div>
         """,
         unsafe_allow_html=True,

--- a/tests/test_news_bar.py
+++ b/tests/test_news_bar.py
@@ -1,0 +1,86 @@
+from streamlit_ui import helpers
+from streamlit_ui import news_bar
+
+
+class _Context:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _StreamlitStub:
+    def __init__(self, *, show_updates=False):
+        self.session_state = {}
+        self.secrets = {}
+        self.markdown_calls = []
+        self.show_updates = show_updates
+
+    def container(self, *_, **__):
+        return _Context()
+
+    def columns(self, spec, *_, **__):
+        if isinstance(spec, int):
+            count = spec
+        else:
+            count = len(spec)
+        return tuple(_Context() for _ in range(count))
+
+    def checkbox(self, _label, value=False, **__):
+        return self.show_updates if self.show_updates is not None else value
+
+    def markdown(self, content, **__):
+        self.markdown_calls.append(content)
+        return None
+
+
+def test_load_live_updates_config_reads_env_values(monkeypatch):
+    monkeypatch.setenv("REPORTING_LIVE_UPDATES_LABEL", "Sector updates")
+    monkeypatch.setenv("REPORTING_LIVE_UPDATES_ITEMS", '["Grid outage watch","Weather advisory"]')
+    monkeypatch.setenv("REPORTING_LIVE_UPDATES_ENABLED_BY_DEFAULT", "true")
+
+    config = news_bar.load_live_updates_config()
+
+    assert config["label"] == "Sector updates"
+    assert config["enabled_by_default"] is True
+    assert config["static_items"] == [
+        {"title": "Grid outage watch", "context": ""},
+        {"title": "Weather advisory", "context": ""},
+    ]
+
+
+def test_load_live_updates_items_prefers_static_items(monkeypatch):
+    monkeypatch.setattr(
+        news_bar,
+        "fetch_feed_updates",
+        lambda *_, **__: [{"title": "Should not be used", "context": ""}],
+    )
+
+    items = news_bar.load_live_updates_items(
+        {
+            "static_items": [
+                {"title": "Infrastructure permit cleared", "context": "infrastructure"},
+                {"title": "Rain alert for Kigali", "context": "weather"},
+            ],
+            "feed_url": "https://example.com/feed.xml",
+            "max_items": 5,
+        }
+    )
+
+    assert items == [
+        {"title": "Infrastructure permit cleared", "context": "infrastructure"},
+        {"title": "Rain alert for Kigali", "context": "weather"},
+    ]
+
+
+def test_render_live_updates_shell_shows_unavailable_state_when_enabled_without_source(monkeypatch):
+    st_stub = _StreamlitStub(show_updates=True)
+    monkeypatch.setattr(news_bar, "st", st_stub)
+    monkeypatch.setattr(helpers, "st", st_stub)
+    monkeypatch.delenv("REPORTING_LIVE_UPDATES_FEED_URL", raising=False)
+    monkeypatch.delenv("REPORTING_LIVE_UPDATES_ITEMS", raising=False)
+
+    news_bar.render_live_updates_shell()
+
+    assert any("News unavailable" in content for content in st_stub.markdown_calls)

--- a/tests/test_reporting_workspace.py
+++ b/tests/test_reporting_workspace.py
@@ -100,6 +100,7 @@ class _StreamlitStub:
 def _patch_layout(monkeypatch):
     monkeypatch.setattr(helpers, "st", reporting_workspace.st)
     monkeypatch.setattr(reporting_workspace, "render_workspace_topbar", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_live_updates_shell", lambda *_, **__: None)
     monkeypatch.setattr(reporting_workspace, "render_card_header", lambda *_, **__: None)
     monkeypatch.setattr(reporting_workspace, "render_kpi_strip", lambda *_, **__: None)
     monkeypatch.setattr(reporting_workspace, "render_note", lambda *_, **__: None)


### PR DESCRIPTION
## Summary
- polish the reporting platform shell with a more authoritative header treatment and tighter top-of-page spacing
- add an optional live updates companion strip for infrastructure, energy, engineering, weather, and safety updates
- keep the live updates feature visually secondary, off by default, and resilient to missing or failing sources
- preserve the existing reporting workflow, filters, uploads, output settings, and report generation behavior

## UI-only scope
- no business logic changes
- no report generation changes
- no sheet behavior changes
- no schema changes
- no OpenAI workflow changes

## Validation
- `pytest`