### PR TITLE
Finalize OpenRouter routing architecture and fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The previous `app.py` god-file was split into clearer layers:
   session-state keys, persistent AI memory, runtime issue store, reset helpers
 - `services/openai_client.py`
   OpenRouter/OpenAI provider selection, key/model loading, SDK checks, general assistant requests
+- `services/model_routing.py`
+  task-based routing profiles, provider-aware model defaults, fallback models, OpenRouter plugin policy
 - `services/converter_service.py`
   contractor conversion/refinement logic, normalization, validation, locking, change summaries
 - `services/media_service.py`
@@ -124,6 +126,49 @@ Provider behavior:
 - OpenRouter mode uses Chat Completions for contractor conversion/refinement, structured JSON output, research, web plugin calls, image captioning, PDF/image/text attachments, and audio-input transcription on compatible models.
 - OpenAI mode remains available for Responses-only tools such as vector-store file search, Code Interpreter spreadsheet analysis, and text-to-speech readback.
 
+### Routing Profiles
+
+OpenRouter support is controlled through `services/model_routing.py`, not by scattering model names through UI code. The current routing profiles are:
+
+- `conversion_strict`
+  Structured contractor-to-consultant conversion with strict JSON output, file-parser support, and response-healing support.
+- `refinement_strict`
+  Structured refinement of converted rows with strict JSON output, file-parser support, and response-healing support.
+- `captioning_vision`
+  Site-photo captions with structured JSON output and optional one-retry fallback.
+- `general_chat_economy`
+  Secondary general assistant chat with lower token budget.
+- `research_tooling`
+  Research assistant routing with optional web/file-parser support.
+- `transcription_audio`
+  Voice-note transcription routing for OpenRouter audio input or OpenAI transcription.
+
+Each profile defines provider-specific primary and fallback models, temperature, token budget, structured-output requirements, and allowed OpenRouter plugins.
+
+Fallback behavior is intentionally limited:
+
+- Contractor conversion and contractor refinement retry once on transient provider/model availability failures.
+- Image captioning also retries once when the configured fallback model differs from the primary model.
+- Schema mismatches, validation errors, unsupported content, and deterministic parsing failures are not retried indefinitely.
+
+To override models without changing workflow code, set profile-specific environment variables:
+
+```powershell
+$env:OPENROUTER_CONVERSION_STRICT_PRIMARY_MODEL = "openai/gpt-4o-mini"
+$env:OPENROUTER_CONVERSION_STRICT_FALLBACK_MODEL = "openai/gpt-4o"
+$env:OPENROUTER_CAPTIONING_VISION_PRIMARY_MODEL = "openai/gpt-4o-mini"
+$env:OPENAI_RESEARCH_TOOLING_PRIMARY_MODEL = "gpt-5.4-mini"
+```
+
+The naming pattern is:
+
+```text
+<PROVIDER>_<ROUTING_PROFILE>_PRIMARY_MODEL
+<PROVIDER>_<ROUTING_PROFILE>_FALLBACK_MODEL
+```
+
+Profile-specific environment overrides take precedence over the general browser/session model field, so production model changes can be made without editing Streamlit workspace code.
+
 ## Google Credentials
 
 The app needs access to the reporting Google Sheet. Add the service account JSON to Streamlit secrets:
@@ -160,10 +205,14 @@ Each event records only known values:
 - timestamp
 - feature name
 - model
+- provider
+- routing profile
+- resolved model
+- whether fallback was used
+- enabled plugin flags
 - whether files were present
 - whether images were present
 - status
-- error summary when a request failed
 
 The diagnostics workspace also shows:
 
@@ -225,6 +274,8 @@ The refactor adds direct tests for:
 - converter validation and field locking
 - change summary behavior
 - usage logging summaries
+- routing profile resolution and fallback behavior
+- non-sensitive provider/routing usage metadata
 - existing AI helper flows
 - OpenRouter provider routing through the shared AI service layer
 - reporting/export compatibility

--- a/services/converter_service.py
+++ b/services/converter_service.py
@@ -25,6 +25,17 @@ from services.openai_client import (
     normalize_ai_provider,
     provider_label,
 )
+from services.model_routing import (
+    PROFILE_CONVERSION_STRICT,
+    PROFILE_REFINEMENT_STRICT,
+    ResolvedRoutingProfile,
+    chat_completion_options,
+    is_transient_ai_error,
+    model_attempts,
+    openrouter_plugins_for_route,
+    plugin_flags_from_plugins,
+    resolve_routing_profile,
+)
 from services.research_service import converter_response_options, extract_response_sources
 from services.usage_logging import log_usage_event
 
@@ -143,23 +154,6 @@ def contractor_refinement_response_schema() -> dict[str, object]:
         "required": ["assistant_message", "reports"],
         "additionalProperties": False,
     }
-
-
-def openrouter_plugins(
-    *,
-    allow_web_research: bool = False,
-    include_file_parser: bool = False,
-    include_response_healing: bool = False,
-) -> list[dict[str, object]]:
-    """Return OpenRouter plugins for chat-completion workflows."""
-    plugins: list[dict[str, object]] = []
-    if allow_web_research:
-        plugins.append({"id": "web"})
-    if include_file_parser:
-        plugins.append({"id": "file-parser", "pdf": {"engine": "cloudflare-ai"}})
-    if include_response_healing:
-        plugins.append({"id": "response-healing"})
-    return plugins
 
 
 def conversation_transcript(messages: list[dict[str, str]]) -> str:
@@ -322,6 +316,159 @@ def summarize_row_changes(
     return summaries
 
 
+def _converter_plugin_flags(
+    route: ResolvedRoutingProfile,
+    *,
+    supporting_files: list[object] | None,
+    allow_web_research: bool,
+) -> tuple[list[dict[str, object]], dict[str, bool]]:
+    plugins = openrouter_plugins_for_route(
+        route,
+        include_web=allow_web_research,
+        include_file_parser=has_pdf_files(supporting_files),
+        include_response_healing=True,
+    )
+    return plugins, plugin_flags_from_plugins(plugins)
+
+
+def _structured_conversion_attempt(
+    *,
+    api_key: str,
+    provider: str,
+    model: str,
+    route: ResolvedRoutingProfile,
+    instructions: str,
+    request_text: str,
+    supporting_files: list[object] | None,
+    allow_web_research: bool,
+    knowledge_vector_store_id: str,
+) -> tuple[str, object, dict[str, bool]]:
+    client = make_ai_client(api_key=api_key, provider=provider)
+    if provider == PROVIDER_OPENROUTER:
+        plugins, plugin_flags = _converter_plugin_flags(
+            route,
+            supporting_files=supporting_files,
+            allow_web_research=allow_web_research,
+        )
+        request_kwargs: dict[str, object] = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": instructions},
+                {
+                    "role": "user",
+                    "content": uploaded_files_to_chat_content(
+                        request_text,
+                        uploaded_files=supporting_files,
+                    ),
+                },
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "consultant_daily_reports",
+                    "strict": True,
+                    "schema": consultant_report_response_schema(),
+                },
+            },
+            **chat_completion_options(route),
+        }
+        if plugins:
+            request_kwargs["extra_body"] = {"plugins": plugins}
+        response = client.chat.completions.create(**request_kwargs)
+        return extract_chat_completion_text(response), response, plugin_flags
+
+    request_input: object = request_text
+    if supporting_files:
+        request_input = uploaded_files_to_response_input(request_text, uploaded_files=supporting_files)
+    response = client.responses.create(
+        model=model,
+        instructions=instructions,
+        input=request_input,
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "consultant_daily_reports",
+                "strict": True,
+                "schema": consultant_report_response_schema(),
+            }
+        },
+        store=False,
+        **converter_response_options(
+            allow_web_research=allow_web_research,
+            knowledge_vector_store_id=knowledge_vector_store_id,
+        ),
+    )
+    return extract_openai_output_text(response), response, plugin_flags_from_plugins([])
+
+
+def _structured_refinement_attempt(
+    *,
+    api_key: str,
+    provider: str,
+    model: str,
+    route: ResolvedRoutingProfile,
+    instructions: str,
+    request_text: str,
+    request_input: object,
+    supporting_files: list[object] | None,
+    allow_web_research: bool,
+    knowledge_vector_store_id: str,
+) -> tuple[str, object, dict[str, bool]]:
+    client = make_ai_client(api_key=api_key, provider=provider)
+    if provider == PROVIDER_OPENROUTER:
+        plugins, plugin_flags = _converter_plugin_flags(
+            route,
+            supporting_files=supporting_files,
+            allow_web_research=allow_web_research,
+        )
+        request_kwargs: dict[str, object] = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": instructions},
+                {
+                    "role": "user",
+                    "content": uploaded_files_to_chat_content(
+                        request_text,
+                        uploaded_files=supporting_files,
+                    ),
+                },
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "consultant_report_refinement",
+                    "strict": True,
+                    "schema": contractor_refinement_response_schema(),
+                },
+            },
+            **chat_completion_options(route),
+        }
+        if plugins:
+            request_kwargs["extra_body"] = {"plugins": plugins}
+        response = client.chat.completions.create(**request_kwargs)
+        return extract_chat_completion_text(response), response, plugin_flags
+
+    response = client.responses.create(
+        model=model,
+        instructions=instructions,
+        input=request_input,
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": "consultant_report_refinement",
+                "strict": True,
+                "schema": contractor_refinement_response_schema(),
+            }
+        },
+        store=False,
+        **converter_response_options(
+            allow_web_research=allow_web_research,
+            knowledge_vector_store_id=knowledge_vector_store_id,
+        ),
+    )
+    return extract_openai_output_text(response), response, plugin_flags_from_plugins([])
+
+
 def request_structured_reports_with_openai(
     raw_report_text: str,
     *,
@@ -380,92 +527,79 @@ def request_structured_reports_with_openai(
 
     request_text = "\n\n".join(prompt_sections)
 
-    resolved_model = converter_model(
-        model,
+    route = resolve_routing_profile(
+        PROFILE_CONVERSION_STRICT,
         provider=normalized_provider,
+        primary_model_override=model,
         allow_web_research=allow_web_research,
-        allow_file_search=bool(knowledge_vector_store_id),
+        allow_file_parser=has_pdf_files(supporting_files),
     )
-    response = None
-    try:
-        client = make_ai_client(api_key=api_key, provider=normalized_provider)
-        if normalized_provider == PROVIDER_OPENROUTER:
-            request_kwargs: dict[str, object] = {
-                "model": resolved_model,
-                "messages": [
-                    {"role": "system", "content": instructions},
-                    {
-                        "role": "user",
-                        "content": uploaded_files_to_chat_content(
-                            request_text,
-                            uploaded_files=supporting_files,
-                        ),
-                    },
-                ],
-                "response_format": {
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": "consultant_daily_reports",
-                        "strict": True,
-                        "schema": consultant_report_response_schema(),
-                    },
-                },
-            }
-            plugins = openrouter_plugins(
-                allow_web_research=allow_web_research,
-                include_file_parser=has_pdf_files(supporting_files),
-                include_response_healing=True,
-            )
-            if plugins:
-                request_kwargs["extra_body"] = {"plugins": plugins}
-            response = client.chat.completions.create(**request_kwargs)
-            payload_text = extract_chat_completion_text(response)
-        else:
-            request_input: object = request_text
-            if supporting_files:
-                request_input = uploaded_files_to_response_input(request_text, uploaded_files=supporting_files)
-            response = client.responses.create(
+    last_exception: Exception | None = None
+    for candidate_model, fallback_used in model_attempts(route):
+        resolved_model = converter_model(
+            candidate_model,
+            provider=normalized_provider,
+            allow_web_research=allow_web_research,
+            allow_file_search=bool(knowledge_vector_store_id),
+        )
+        try:
+            payload_text, response, plugin_flags = _structured_conversion_attempt(
+                api_key=api_key,
+                provider=normalized_provider,
                 model=resolved_model,
+                route=route,
                 instructions=instructions,
-                input=request_input,
-                text={
-                    "format": {
-                        "type": "json_schema",
-                        "name": "consultant_daily_reports",
-                        "strict": True,
-                        "schema": consultant_report_response_schema(),
-                    }
-                },
-                store=False,
-                **converter_response_options(
-                    allow_web_research=allow_web_research,
-                    knowledge_vector_store_id=knowledge_vector_store_id,
-                ),
+                request_text=request_text,
+                supporting_files=supporting_files,
+                allow_web_research=allow_web_research,
+                knowledge_vector_store_id=knowledge_vector_store_id,
             )
-            payload_text = extract_openai_output_text(response)
-        if not payload_text:
-            raise ValueError(f"{provider_label(normalized_provider)} returned an empty structured output.")
-        payload = json.loads(payload_text)
-        rows = normalize_structured_rows(structured_report_rows(payload))
-    except Exception as exc:
+            if not payload_text:
+                raise ValueError(f"{provider_label(normalized_provider)} returned an empty structured output.")
+            payload = json.loads(payload_text)
+            rows = normalize_structured_rows(structured_report_rows(payload))
+        except Exception as exc:
+            last_exception = exc
+            should_retry = (
+                not fallback_used
+                and route.fallback_model
+                and route.fallback_model != candidate_model
+                and is_transient_ai_error(exc)
+            )
+            log_usage_event(
+                feature_name="contractor_conversion",
+                model=resolved_model,
+                has_files=bool(supporting_files),
+                has_images=has_image_files(supporting_files),
+                status="failed",
+                error_summary=str(exc),
+                provider=normalized_provider,
+                routing_profile=route.name,
+                resolved_model=resolved_model,
+                fallback_used=fallback_used,
+                plugin_flags=plugin_flags_from_plugins([]),
+            )
+            if should_retry:
+                continue
+            raise
+
         log_usage_event(
             feature_name="contractor_conversion",
             model=resolved_model,
             has_files=bool(supporting_files),
             has_images=has_image_files(supporting_files),
-            status="failed",
-            error_summary=str(exc),
+            status="success",
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=fallback_used,
+            plugin_flags=plugin_flags,
         )
-        raise
+        return rows, extract_response_sources(response) if normalized_provider == PROVIDER_OPENAI else []
 
-    log_usage_event(
-        feature_name="contractor_conversion",
-        model=resolved_model,
-        has_files=bool(supporting_files),
-        has_images=has_image_files(supporting_files),
-        status="success",
-    )
-    return rows, extract_response_sources(response) if normalized_provider == PROVIDER_OPENAI else []
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("No contractor conversion model attempt was available.")
 
 
 def request_refined_structured_reports_with_openai(
@@ -536,88 +670,79 @@ def request_refined_structured_reports_with_openai(
     if supporting_files and normalized_provider == PROVIDER_OPENAI:
         request_input = uploaded_files_to_response_input(request_text, uploaded_files=supporting_files)
 
-    resolved_model = converter_model(
-        model,
+    route = resolve_routing_profile(
+        PROFILE_REFINEMENT_STRICT,
         provider=normalized_provider,
+        primary_model_override=model,
         allow_web_research=allow_web_research,
-        allow_file_search=bool(knowledge_vector_store_id),
+        allow_file_parser=has_pdf_files(supporting_files),
     )
-    response = None
-    try:
-        client = make_ai_client(api_key=api_key, provider=normalized_provider)
-        if normalized_provider == PROVIDER_OPENROUTER:
-            request_kwargs: dict[str, object] = {
-                "model": resolved_model,
-                "messages": [
-                    {"role": "system", "content": instructions},
-                    {
-                        "role": "user",
-                        "content": uploaded_files_to_chat_content(
-                            request_text,
-                            uploaded_files=supporting_files,
-                        ),
-                    },
-                ],
-                "response_format": {
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": "consultant_report_refinement",
-                        "strict": True,
-                        "schema": contractor_refinement_response_schema(),
-                    },
-                },
-            }
-            plugins = openrouter_plugins(
-                allow_web_research=allow_web_research,
-                include_file_parser=has_pdf_files(supporting_files),
-                include_response_healing=True,
-            )
-            if plugins:
-                request_kwargs["extra_body"] = {"plugins": plugins}
-            response = client.chat.completions.create(**request_kwargs)
-            payload_text = extract_chat_completion_text(response)
-        else:
-            response = client.responses.create(
+    last_exception: Exception | None = None
+    for candidate_model, fallback_used in model_attempts(route):
+        resolved_model = converter_model(
+            candidate_model,
+            provider=normalized_provider,
+            allow_web_research=allow_web_research,
+            allow_file_search=bool(knowledge_vector_store_id),
+        )
+        try:
+            payload_text, response, plugin_flags = _structured_refinement_attempt(
+                api_key=api_key,
+                provider=normalized_provider,
                 model=resolved_model,
+                route=route,
                 instructions=instructions,
-                input=request_input,
-                text={
-                    "format": {
-                        "type": "json_schema",
-                        "name": "consultant_report_refinement",
-                        "strict": True,
-                        "schema": contractor_refinement_response_schema(),
-                    }
-                },
-                store=False,
-                **converter_response_options(
-                    allow_web_research=allow_web_research,
-                    knowledge_vector_store_id=knowledge_vector_store_id,
-                ),
+                request_text=request_text,
+                request_input=request_input,
+                supporting_files=supporting_files,
+                allow_web_research=allow_web_research,
+                knowledge_vector_store_id=knowledge_vector_store_id,
             )
-            payload_text = extract_openai_output_text(response)
-        if not payload_text:
-            raise ValueError(f"{provider_label(normalized_provider)} returned an empty refinement output.")
-        payload = json.loads(payload_text)
-        assistant_message = str(payload.get("assistant_message", "") or "").strip() or "I updated the converted consultant rows."
-        rows = normalize_structured_rows(structured_report_rows(payload.get("reports", [])))
-    except Exception as exc:
+            if not payload_text:
+                raise ValueError(f"{provider_label(normalized_provider)} returned an empty refinement output.")
+            payload = json.loads(payload_text)
+            assistant_message = str(payload.get("assistant_message", "") or "").strip() or "I updated the converted consultant rows."
+            rows = normalize_structured_rows(structured_report_rows(payload.get("reports", [])))
+        except Exception as exc:
+            last_exception = exc
+            should_retry = (
+                not fallback_used
+                and route.fallback_model
+                and route.fallback_model != candidate_model
+                and is_transient_ai_error(exc)
+            )
+            log_usage_event(
+                feature_name="contractor_refinement",
+                model=resolved_model,
+                has_files=bool(supporting_files),
+                has_images=has_image_files(supporting_files),
+                status="failed",
+                error_summary=str(exc),
+                provider=normalized_provider,
+                routing_profile=route.name,
+                resolved_model=resolved_model,
+                fallback_used=fallback_used,
+                plugin_flags=plugin_flags_from_plugins([]),
+            )
+            if should_retry:
+                continue
+            raise
+
         log_usage_event(
             feature_name="contractor_refinement",
             model=resolved_model,
             has_files=bool(supporting_files),
             has_images=has_image_files(supporting_files),
-            status="failed",
-            error_summary=str(exc),
+            status="success",
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=fallback_used,
+            plugin_flags=plugin_flags,
         )
-        raise
+        return assistant_message, rows, extract_response_sources(response) if normalized_provider == PROVIDER_OPENAI else []
 
-    log_usage_event(
-        feature_name="contractor_refinement",
-        model=resolved_model,
-        has_files=bool(supporting_files),
-        has_images=has_image_files(supporting_files),
-        status="success",
-    )
-    return assistant_message, rows, extract_response_sources(response) if normalized_provider == PROVIDER_OPENAI else []
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("No contractor refinement model attempt was available.")
 

--- a/services/media_service.py
+++ b/services/media_service.py
@@ -15,13 +15,21 @@ from report_structuring import REPORT_HEADERS
 from services.openai_client import (
     PROVIDER_OPENAI,
     PROVIDER_OPENROUTER,
-    TRANSCRIPTION_OPENAI_MODEL,
-    TRANSCRIPTION_OPENROUTER_MODEL,
     TTS_OPENAI_MODEL,
     extract_chat_completion_text,
     extract_openai_output_text,
     make_ai_client,
     normalize_ai_provider,
+)
+from services.model_routing import (
+    PROFILE_CAPTIONING_VISION,
+    PROFILE_TRANSCRIPTION_AUDIO,
+    chat_completion_options,
+    is_transient_ai_error,
+    model_attempts,
+    openrouter_plugins_for_route,
+    plugin_flags_from_plugins,
+    resolve_routing_profile,
 )
 from services.usage_logging import log_usage_event
 
@@ -257,6 +265,11 @@ def request_image_captions_with_openai(
     if not images:
         return []
     normalized_provider = normalize_ai_provider(provider)
+    route = resolve_routing_profile(
+        PROFILE_CAPTIONING_VISION,
+        provider=normalized_provider,
+        primary_model_override=model,
+    )
 
     instructions = textwrap.dedent(
         f"""
@@ -280,91 +293,122 @@ def request_image_captions_with_openai(
         "Generate captions for the attached site photos."
     )
 
-    try:
-        if normalized_provider == PROVIDER_OPENROUTER:
-            content: list[dict[str, object]] = [{"type": "text", "text": prompt_text}]
-            for image_bytes in images:
-                payload = bytes(image_bytes or b"")
-                content.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": data_url_for_bytes(
+    last_exception: Exception | None = None
+    for resolved_model, fallback_used in model_attempts(route):
+        plugins = openrouter_plugins_for_route(route, include_response_healing=True)
+        plugin_flags = plugin_flags_from_plugins(plugins)
+        try:
+            if normalized_provider == PROVIDER_OPENROUTER:
+                content: list[dict[str, object]] = [{"type": "text", "text": prompt_text}]
+                for image_bytes in images:
+                    payload = bytes(image_bytes or b"")
+                    content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": data_url_for_bytes(
+                                    payload,
+                                    mime_type=image_mime_type_from_bytes(payload),
+                                )
+                            },
+                        }
+                    )
+                request_kwargs: dict[str, object] = {
+                    "model": resolved_model,
+                    "messages": [
+                        {"role": "system", "content": instructions},
+                        {"role": "user", "content": content},
+                    ],
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "site_photo_captions",
+                            "strict": True,
+                            "schema": photo_caption_response_schema(len(images)),
+                        },
+                    },
+                    **chat_completion_options(route),
+                }
+                if plugins:
+                    request_kwargs["extra_body"] = {"plugins": plugins}
+                response = make_ai_client(api_key=api_key, provider=normalized_provider).chat.completions.create(**request_kwargs)
+                payload_text = extract_chat_completion_text(response)
+            else:
+                content: list[dict[str, str]] = [{"type": "input_text", "text": prompt_text}]
+                for image_bytes in images:
+                    payload = bytes(image_bytes or b"")
+                    content.append(
+                        {
+                            "type": "input_image",
+                            "image_url": data_url_for_bytes(
                                 payload,
                                 mime_type=image_mime_type_from_bytes(payload),
-                            )
-                        },
-                    }
-                )
-            response = make_ai_client(api_key=api_key, provider=normalized_provider).chat.completions.create(
-                model=model,
-                messages=[
-                    {"role": "system", "content": instructions},
-                    {"role": "user", "content": content},
-                ],
-                response_format={
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": "site_photo_captions",
-                        "strict": True,
-                        "schema": photo_caption_response_schema(len(images)),
+                            ),
+                        }
+                    )
+                response = make_ai_client(api_key=api_key, provider=normalized_provider).responses.create(
+                    model=resolved_model,
+                    instructions=instructions,
+                    input=[{"role": "user", "content": content}],
+                    text={
+                        "format": {
+                            "type": "json_schema",
+                            "name": "site_photo_captions",
+                            "strict": True,
+                            "schema": photo_caption_response_schema(len(images)),
+                        }
                     },
-                }
-            )
-            payload_text = extract_chat_completion_text(response)
-        else:
-            content: list[dict[str, str]] = [{"type": "input_text", "text": prompt_text}]
-            for image_bytes in images:
-                payload = bytes(image_bytes or b"")
-                content.append(
-                    {
-                        "type": "input_image",
-                        "image_url": data_url_for_bytes(
-                            payload,
-                            mime_type=image_mime_type_from_bytes(payload),
-                        ),
-                    }
+                    store=False,
                 )
-            response = make_ai_client(api_key=api_key, provider=normalized_provider).responses.create(
-                model=model,
-                instructions=instructions,
-                input=[{"role": "user", "content": content}],
-                text={
-                    "format": {
-                        "type": "json_schema",
-                        "name": "site_photo_captions",
-                        "strict": True,
-                        "schema": photo_caption_response_schema(len(images)),
-                    }
-                },
-                store=False,
+                payload_text = extract_openai_output_text(response)
+            if not payload_text:
+                raise ValueError(f"{'OpenRouter' if normalized_provider == PROVIDER_OPENROUTER else 'OpenAI'} returned empty photo captions.")
+            payload = json.loads(payload_text)
+            captions = payload.get("captions", [])
+            if not isinstance(captions, list):
+                raise ValueError("The AI provider returned invalid photo captions.")
+        except Exception as exc:
+            last_exception = exc
+            should_retry = (
+                not fallback_used
+                and route.fallback_model
+                and route.fallback_model != resolved_model
+                and is_transient_ai_error(exc)
             )
-            payload_text = extract_openai_output_text(response)
-        if not payload_text:
-            raise ValueError(f"{'OpenRouter' if normalized_provider == PROVIDER_OPENROUTER else 'OpenAI'} returned empty photo captions.")
-        payload = json.loads(payload_text)
-        captions = payload.get("captions", [])
-        if not isinstance(captions, list):
-            raise ValueError("The AI provider returned invalid photo captions.")
-    except Exception as exc:
+            log_usage_event(
+                feature_name="image_captioning",
+                model=resolved_model,
+                has_files=True,
+                has_images=True,
+                status="failed",
+                error_summary=str(exc),
+                provider=normalized_provider,
+                routing_profile=route.name,
+                resolved_model=resolved_model,
+                fallback_used=fallback_used,
+                plugin_flags=plugin_flags,
+            )
+            if should_retry:
+                continue
+            raise
+
         log_usage_event(
             feature_name="image_captioning",
-            model=model,
+            model=resolved_model,
             has_files=True,
             has_images=True,
-            status="failed",
-            error_summary=str(exc),
+            status="success",
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=fallback_used,
+            plugin_flags=plugin_flags,
         )
-        raise
+        return [str(caption or "").strip() for caption in captions]
 
-    log_usage_event(
-        feature_name="image_captioning",
-        model=model,
-        has_files=True,
-        has_images=True,
-        status="success",
-    )
-    return [str(caption or "").strip() for caption in captions]
+    if last_exception:
+        raise last_exception
+    raise RuntimeError("No image-captioning model attempt was available.")
 
 
 def request_transcription_with_openai(
@@ -379,7 +423,8 @@ def request_transcription_with_openai(
     if not audio_files:
         raise ValueError("Upload at least one voice note before requesting transcription.")
     normalized_provider = normalize_ai_provider(provider)
-    model = TRANSCRIPTION_OPENROUTER_MODEL if normalized_provider == PROVIDER_OPENROUTER else TRANSCRIPTION_OPENAI_MODEL
+    route = resolve_routing_profile(PROFILE_TRANSCRIPTION_AUDIO, provider=normalized_provider)
+    model = route.primary_model
 
     prompt = (
         f"This is a {discipline.lower()} construction site voice note for a daily report in Rwanda. "
@@ -414,6 +459,7 @@ def request_transcription_with_openai(
                             ],
                         },
                     ],
+                    **chat_completion_options(route),
                 )
                 transcript_text = extract_chat_completion_text(response)
             else:
@@ -442,6 +488,11 @@ def request_transcription_with_openai(
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=model,
+            fallback_used=False,
+            plugin_flags=plugin_flags_from_plugins([]),
         )
         raise
 
@@ -451,6 +502,11 @@ def request_transcription_with_openai(
         has_files=True,
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        routing_profile=route.name,
+        resolved_model=model,
+        fallback_used=False,
+        plugin_flags=plugin_flags_from_plugins([]),
     )
     return "\n\n".join(transcripts)
 
@@ -488,6 +544,11 @@ def request_text_to_speech_with_openai(
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            routing_profile="",
+            resolved_model=TTS_OPENAI_MODEL,
+            fallback_used=False,
+            plugin_flags=plugin_flags_from_plugins([]),
         )
         raise
 
@@ -497,6 +558,11 @@ def request_text_to_speech_with_openai(
         has_files=False,
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        routing_profile="",
+        resolved_model=TTS_OPENAI_MODEL,
+        fallback_used=False,
+        plugin_flags=plugin_flags_from_plugins([]),
     )
     return audio_bytes
 

--- a/services/model_routing.py
+++ b/services/model_routing.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping
+
+PROVIDER_OPENROUTER = "openrouter"
+PROVIDER_OPENAI = "openai"
+SUPPORTED_AI_PROVIDERS = (PROVIDER_OPENROUTER, PROVIDER_OPENAI)
+DEFAULT_AI_PROVIDER = PROVIDER_OPENROUTER
+
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
+RESEARCH_OPENAI_MODEL = "gpt-5.4-mini"
+TRANSCRIPTION_OPENAI_MODEL = "gpt-4o-transcribe"
+TTS_OPENAI_MODEL = "gpt-4o-mini-tts"
+DEFAULT_OPENROUTER_MODEL = "openai/gpt-4o-mini"
+RESEARCH_OPENROUTER_MODEL = "openai/gpt-4o-mini"
+FALLBACK_OPENROUTER_MODEL = "openai/gpt-4o"
+TRANSCRIPTION_OPENROUTER_MODEL = "openai/gpt-audio-mini"
+
+PROFILE_CONVERSION_STRICT = "conversion_strict"
+PROFILE_REFINEMENT_STRICT = "refinement_strict"
+PROFILE_CAPTIONING_VISION = "captioning_vision"
+PROFILE_GENERAL_CHAT_ECONOMY = "general_chat_economy"
+PROFILE_RESEARCH_TOOLING = "research_tooling"
+PROFILE_TRANSCRIPTION_AUDIO = "transcription_audio"
+
+
+@dataclass(frozen=True)
+class RoutingProfile:
+    """Task-level routing policy before provider-specific resolution."""
+
+    name: str
+    primary_models: Mapping[str, str]
+    fallback_models: Mapping[str, str]
+    temperature: float | None = None
+    max_tokens: int | None = None
+    structured_output_required: bool = False
+    web_research_allowed: bool = False
+    file_parser_allowed: bool = False
+    response_healing_allowed: bool = False
+
+
+@dataclass(frozen=True)
+class ResolvedRoutingProfile:
+    """Provider-specific routing policy for one request."""
+
+    name: str
+    provider: str
+    primary_model: str
+    fallback_model: str
+    temperature: float | None
+    max_tokens: int | None
+    structured_output_required: bool
+    web_research_allowed: bool
+    file_parser_allowed: bool
+    response_healing_allowed: bool
+
+
+ROUTING_PROFILES: dict[str, RoutingProfile] = {
+    PROFILE_CONVERSION_STRICT: RoutingProfile(
+        name=PROFILE_CONVERSION_STRICT,
+        primary_models={
+            PROVIDER_OPENROUTER: DEFAULT_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: FALLBACK_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: RESEARCH_OPENAI_MODEL,
+        },
+        temperature=0.2,
+        max_tokens=6000,
+        structured_output_required=True,
+        web_research_allowed=False,
+        file_parser_allowed=True,
+        response_healing_allowed=True,
+    ),
+    PROFILE_REFINEMENT_STRICT: RoutingProfile(
+        name=PROFILE_REFINEMENT_STRICT,
+        primary_models={
+            PROVIDER_OPENROUTER: DEFAULT_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: FALLBACK_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: RESEARCH_OPENAI_MODEL,
+        },
+        temperature=0.2,
+        max_tokens=7000,
+        structured_output_required=True,
+        web_research_allowed=False,
+        file_parser_allowed=True,
+        response_healing_allowed=True,
+    ),
+    PROFILE_CAPTIONING_VISION: RoutingProfile(
+        name=PROFILE_CAPTIONING_VISION,
+        primary_models={
+            PROVIDER_OPENROUTER: DEFAULT_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: FALLBACK_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        temperature=0.1,
+        max_tokens=1200,
+        structured_output_required=True,
+        web_research_allowed=False,
+        file_parser_allowed=False,
+        response_healing_allowed=True,
+    ),
+    PROFILE_GENERAL_CHAT_ECONOMY: RoutingProfile(
+        name=PROFILE_GENERAL_CHAT_ECONOMY,
+        primary_models={
+            PROVIDER_OPENROUTER: DEFAULT_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: FALLBACK_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: DEFAULT_OPENAI_MODEL,
+        },
+        temperature=0.4,
+        max_tokens=3000,
+        structured_output_required=False,
+        web_research_allowed=False,
+        file_parser_allowed=False,
+        response_healing_allowed=False,
+    ),
+    PROFILE_RESEARCH_TOOLING: RoutingProfile(
+        name=PROFILE_RESEARCH_TOOLING,
+        primary_models={
+            PROVIDER_OPENROUTER: RESEARCH_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: RESEARCH_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: FALLBACK_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: RESEARCH_OPENAI_MODEL,
+        },
+        temperature=0.2,
+        max_tokens=5000,
+        structured_output_required=False,
+        web_research_allowed=True,
+        file_parser_allowed=True,
+        response_healing_allowed=False,
+    ),
+    PROFILE_TRANSCRIPTION_AUDIO: RoutingProfile(
+        name=PROFILE_TRANSCRIPTION_AUDIO,
+        primary_models={
+            PROVIDER_OPENROUTER: TRANSCRIPTION_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: TRANSCRIPTION_OPENAI_MODEL,
+        },
+        fallback_models={
+            PROVIDER_OPENROUTER: DEFAULT_OPENROUTER_MODEL,
+            PROVIDER_OPENAI: TRANSCRIPTION_OPENAI_MODEL,
+        },
+        temperature=0,
+        max_tokens=4000,
+        structured_output_required=False,
+        web_research_allowed=False,
+        file_parser_allowed=False,
+        response_healing_allowed=False,
+    ),
+}
+
+
+def normalize_ai_provider(provider: str | None) -> str:
+    value = str(provider or "").strip().lower()
+    if value in SUPPORTED_AI_PROVIDERS:
+        return value
+    return DEFAULT_AI_PROVIDER
+
+
+def provider_label(provider: str | None = None) -> str:
+    return "OpenRouter" if normalize_ai_provider(provider) == PROVIDER_OPENROUTER else "OpenAI"
+
+
+def _override_env_name(profile_name: str, provider: str, kind: str) -> str:
+    return f"{provider}_{profile_name}_{kind}_model".upper()
+
+
+def _model_override(profile_name: str, provider: str, kind: str) -> str:
+    return os.environ.get(_override_env_name(profile_name, provider, kind), "").strip()
+
+
+def resolve_routing_profile(
+    profile_name: str,
+    *,
+    provider: str | None,
+    primary_model_override: str = "",
+    fallback_model_override: str = "",
+    allow_web_research: bool | None = None,
+    allow_file_parser: bool | None = None,
+    allow_response_healing: bool | None = None,
+) -> ResolvedRoutingProfile:
+    """Resolve one task routing profile for a provider.
+
+    Model override precedence is profile-specific environment override,
+    explicit function override, profile default. Environment names use:
+    `<PROVIDER>_<PROFILE>_PRIMARY_MODEL` and
+    `<PROVIDER>_<PROFILE>_FALLBACK_MODEL`.
+    """
+    normalized_provider = normalize_ai_provider(provider)
+    profile = ROUTING_PROFILES[profile_name]
+    primary_model = (
+        _model_override(profile_name, normalized_provider, "primary")
+        or str(primary_model_override or "").strip()
+        or profile.primary_models[normalized_provider]
+    )
+    fallback_model = (
+        _model_override(profile_name, normalized_provider, "fallback")
+        or str(fallback_model_override or "").strip()
+        or profile.fallback_models[normalized_provider]
+    )
+    return ResolvedRoutingProfile(
+        name=profile.name,
+        provider=normalized_provider,
+        primary_model=primary_model,
+        fallback_model=fallback_model,
+        temperature=profile.temperature,
+        max_tokens=profile.max_tokens,
+        structured_output_required=profile.structured_output_required,
+        web_research_allowed=profile.web_research_allowed if allow_web_research is None else bool(allow_web_research),
+        file_parser_allowed=profile.file_parser_allowed if allow_file_parser is None else bool(allow_file_parser),
+        response_healing_allowed=profile.response_healing_allowed if allow_response_healing is None else bool(allow_response_healing),
+    )
+
+
+def model_attempts(route: ResolvedRoutingProfile) -> list[tuple[str, bool]]:
+    attempts = [(route.primary_model, False)]
+    if route.fallback_model and route.fallback_model != route.primary_model:
+        attempts.append((route.fallback_model, True))
+    return attempts
+
+
+def openrouter_plugins_for_route(
+    route: ResolvedRoutingProfile,
+    *,
+    include_web: bool = False,
+    include_file_parser: bool = False,
+    include_response_healing: bool = False,
+) -> list[dict[str, object]]:
+    """Return OpenRouter plugins allowed by the route and requested by context."""
+    plugins: list[dict[str, object]] = []
+    if route.web_research_allowed and include_web:
+        plugins.append({"id": "web"})
+    if route.file_parser_allowed and include_file_parser:
+        plugins.append({"id": "file-parser", "pdf": {"engine": "cloudflare-ai"}})
+    if route.response_healing_allowed and include_response_healing:
+        plugins.append({"id": "response-healing"})
+    return plugins
+
+
+def plugin_flags_from_plugins(plugins: list[dict[str, object]] | None) -> dict[str, bool]:
+    plugin_ids = {str(plugin.get("id", "") or "").strip() for plugin in plugins or []}
+    return {
+        "web": "web" in plugin_ids,
+        "file_parser": "file-parser" in plugin_ids,
+        "response_healing": "response-healing" in plugin_ids,
+    }
+
+
+def chat_completion_options(route: ResolvedRoutingProfile) -> dict[str, object]:
+    options: dict[str, object] = {}
+    if route.temperature is not None:
+        options["temperature"] = route.temperature
+    if route.max_tokens:
+        options["max_tokens"] = route.max_tokens
+    return options
+
+
+def is_transient_ai_error(exc: Exception) -> bool:
+    """Return whether a failed provider/model call is worth one fallback retry."""
+    status_code = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if isinstance(status_code, int) and status_code in {408, 409, 429, 500, 502, 503, 504}:
+        return True
+
+    message = str(exc or "").lower()
+    transient_markers = (
+        "rate limit",
+        "timeout",
+        "timed out",
+        "temporar",
+        "try again",
+        "overloaded",
+        "unavailable",
+        "capacity",
+        "no endpoints",
+        "no available",
+        "provider returned error",
+        "model unavailable",
+        "model not available",
+        "model not found",
+    )
+    return any(marker in message for marker in transient_markers)

--- a/services/openai_client.py
+++ b/services/openai_client.py
@@ -13,22 +13,28 @@ from core.session_state import (
     OPENROUTER_API_KEY_SESSION_KEY,
     OPENROUTER_MODEL_SESSION_KEY,
 )
+from services.model_routing import (
+    DEFAULT_AI_PROVIDER,
+    DEFAULT_OPENAI_MODEL,
+    DEFAULT_OPENROUTER_MODEL,
+    PROFILE_GENERAL_CHAT_ECONOMY,
+    PROFILE_RESEARCH_TOOLING,
+    PROVIDER_OPENAI,
+    PROVIDER_OPENROUTER,
+    RESEARCH_OPENAI_MODEL,
+    SUPPORTED_AI_PROVIDERS,
+    TRANSCRIPTION_OPENAI_MODEL,
+    TRANSCRIPTION_OPENROUTER_MODEL,
+    TTS_OPENAI_MODEL,
+    chat_completion_options,
+    normalize_ai_provider,
+    provider_label,
+    resolve_routing_profile,
+)
 from services.usage_logging import log_usage_event
 
-PROVIDER_OPENROUTER = "openrouter"
-PROVIDER_OPENAI = "openai"
-SUPPORTED_AI_PROVIDERS = (PROVIDER_OPENROUTER, PROVIDER_OPENAI)
-DEFAULT_AI_PROVIDER = PROVIDER_OPENROUTER
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_APP_TITLE = "IBC 15kV Reporting Platform"
-
-DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
-RESEARCH_OPENAI_MODEL = "gpt-5.4-mini"
-TRANSCRIPTION_OPENAI_MODEL = "gpt-4o-transcribe"
-TTS_OPENAI_MODEL = "gpt-4o-mini-tts"
-DEFAULT_OPENROUTER_MODEL = "openai/gpt-4o-mini"
-RESEARCH_OPENROUTER_MODEL = "openai/gpt-4o-mini"
-TRANSCRIPTION_OPENROUTER_MODEL = "openai/gpt-audio-mini"
 
 OPENAI_ONLY_RESPONSES_FEATURE_MESSAGE = (
     "This feature still uses OpenAI Responses tools. Switch the AI provider to OpenAI for this workflow."
@@ -41,20 +47,6 @@ def streamlit_secret(name: str, default: str = "") -> str:
         return str(st.secrets.get(name, default) or "").strip()
     except Exception:
         return str(default or "").strip()
-
-
-def normalize_ai_provider(provider: str | None) -> str:
-    """Return a supported AI provider id."""
-    value = str(provider or "").strip().lower()
-    if value in SUPPORTED_AI_PROVIDERS:
-        return value
-    return DEFAULT_AI_PROVIDER
-
-
-def provider_label(provider: str | None = None) -> str:
-    """Return a display label for an AI provider."""
-    normalized = normalize_ai_provider(provider or active_ai_provider())
-    return "OpenRouter" if normalized == PROVIDER_OPENROUTER else "OpenAI"
 
 
 def _configured_provider_key(provider: str) -> str:
@@ -261,6 +253,12 @@ def request_openai_reply(
 ) -> tuple[str, str]:
     """Send one general assistant turn and return (reply_text, response_id)."""
     normalized_provider = normalize_ai_provider(provider)
+    route = resolve_routing_profile(
+        PROFILE_GENERAL_CHAT_ECONOMY,
+        provider=normalized_provider,
+        primary_model_override=model,
+    )
+    resolved_model = route.primary_model
     client = make_ai_client(api_key=api_key, provider=normalized_provider)
 
     if normalized_provider == PROVIDER_OPENROUTER:
@@ -281,33 +279,42 @@ def request_openai_reply(
 
         try:
             response = client.chat.completions.create(
-                model=model,
+                model=resolved_model,
                 messages=messages,
+                **chat_completion_options(route),
             )
             reply_text = extract_chat_completion_text(response) or "No text response was returned."
         except Exception as exc:
             log_usage_event(
                 feature_name="general_chat",
-                model=model,
+                model=resolved_model,
                 has_files=False,
                 has_images=False,
                 status="failed",
                 error_summary=str(exc),
+                provider=normalized_provider,
+                routing_profile=route.name,
+                resolved_model=resolved_model,
+                fallback_used=False,
             )
             raise
 
         log_usage_event(
             feature_name="general_chat",
-            model=model,
+            model=resolved_model,
             has_files=False,
             has_images=False,
             status="success",
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=False,
         )
         return reply_text, ""
 
     previous_response_id = st.session_state.get(OPENAI_PREVIOUS_RESPONSE_ID_KEY)
     request_kwargs = {
-        "model": model,
+        "model": resolved_model,
         "input": [{"role": "user", "content": prompt}],
     }
     if previous_response_id:
@@ -319,20 +326,28 @@ def request_openai_reply(
     except Exception as exc:
         log_usage_event(
             feature_name="general_chat",
-            model=model,
+            model=resolved_model,
             has_files=False,
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=False,
         )
         raise
 
     log_usage_event(
         feature_name="general_chat",
-        model=model,
+        model=resolved_model,
         has_files=False,
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        routing_profile=route.name,
+        resolved_model=resolved_model,
+        fallback_used=False,
     )
     return reply_text, str(getattr(response, "id", "") or "")
 
@@ -347,7 +362,8 @@ def tool_enabled_model(
 ) -> str:
     """Return a tool-capable model when one is required."""
     if normalize_ai_provider(provider) == PROVIDER_OPENROUTER:
-        return model or RESEARCH_OPENROUTER_MODEL
+        route = resolve_routing_profile(PROFILE_RESEARCH_TOOLING, provider=provider)
+        return model or route.primary_model
     if not any((allow_web_research, allow_file_search, allow_code_interpreter)):
         return model
     if str(model or "").startswith("gpt-5"):

--- a/services/research_service.py
+++ b/services/research_service.py
@@ -27,6 +27,13 @@ from services.openai_client import (
     provider_supports_openai_responses_tools,
     tool_enabled_model,
 )
+from services.model_routing import (
+    PROFILE_RESEARCH_TOOLING,
+    chat_completion_options,
+    openrouter_plugins_for_route,
+    plugin_flags_from_plugins,
+    resolve_routing_profile,
+)
 from services.usage_logging import log_usage_event
 
 
@@ -151,23 +158,6 @@ def converter_response_options(
     }
 
 
-def openrouter_chat_plugins(
-    *,
-    allow_web_research: bool = False,
-    include_file_parser: bool = False,
-    include_response_healing: bool = False,
-) -> list[dict[str, object]]:
-    """Return OpenRouter plugin configuration for chat-completion requests."""
-    plugins: list[dict[str, object]] = []
-    if allow_web_research:
-        plugins.append({"id": "web"})
-    if include_file_parser:
-        plugins.append({"id": "file-parser", "pdf": {"engine": "cloudflare-ai"}})
-    if include_response_healing:
-        plugins.append({"id": "response-healing"})
-    return plugins
-
-
 def knowledge_vector_store_cache() -> dict[str, object]:
     return st.session_state.setdefault(PROJECT_KNOWLEDGE_VECTOR_STORE_KEY, {})
 
@@ -281,13 +271,21 @@ def request_research_assistant_reply(
         """
     ).strip()
 
+    route = resolve_routing_profile(
+        PROFILE_RESEARCH_TOOLING,
+        provider=normalized_provider,
+        primary_model_override=model,
+        allow_web_research=allow_web_research,
+        allow_file_parser=has_pdf_files(supporting_files),
+    )
     resolved_model = tool_enabled_model(
-        model,
+        route.primary_model,
         provider=normalized_provider,
         allow_web_research=allow_web_research,
         allow_file_search=bool(knowledge_vector_store_id),
     )
     response = None
+    plugin_flags = plugin_flags_from_plugins([])
     try:
         client = make_ai_client(api_key=api_key, provider=normalized_provider)
         if normalized_provider == PROVIDER_OPENROUTER:
@@ -303,11 +301,14 @@ def request_research_assistant_reply(
                         ),
                     },
                 ],
+                **chat_completion_options(route),
             }
-            plugins = openrouter_chat_plugins(
-                allow_web_research=allow_web_research,
+            plugins = openrouter_plugins_for_route(
+                route,
+                include_web=allow_web_research,
                 include_file_parser=has_pdf_files(supporting_files),
             )
+            plugin_flags = plugin_flags_from_plugins(plugins)
             if plugins:
                 request_kwargs["extra_body"] = {"plugins": plugins}
             response = client.chat.completions.create(**request_kwargs)
@@ -334,6 +335,11 @@ def request_research_assistant_reply(
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            routing_profile=route.name,
+            resolved_model=resolved_model,
+            fallback_used=False,
+            plugin_flags=plugin_flags,
         )
         raise
 
@@ -343,6 +349,11 @@ def request_research_assistant_reply(
         has_files=bool(knowledge_vector_store_id or supporting_files),
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        routing_profile=route.name,
+        resolved_model=resolved_model,
+        fallback_used=False,
+        plugin_flags=plugin_flags,
     )
     return reply_text, extract_response_sources(response) if normalized_provider == PROVIDER_OPENAI else []
 
@@ -404,6 +415,10 @@ def request_spreadsheet_analysis_with_openai(
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            resolved_model=resolved_model,
+            fallback_used=False,
+            plugin_flags=plugin_flags_from_plugins([]),
         )
         raise
 
@@ -413,6 +428,10 @@ def request_spreadsheet_analysis_with_openai(
         has_files=True,
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        resolved_model=resolved_model,
+        fallback_used=False,
+        plugin_flags=plugin_flags_from_plugins([]),
     )
     return analysis_text, extract_container_artifacts(response)
 

--- a/services/self_healing_service.py
+++ b/services/self_healing_service.py
@@ -13,6 +13,7 @@ from services.openai_client import (
     normalize_ai_provider,
     provider_label,
 )
+from services.model_routing import plugin_flags_from_plugins
 from services.usage_logging import log_usage_event
 
 
@@ -123,6 +124,10 @@ def request_self_healing_analysis_with_openai(
             has_images=False,
             status="failed",
             error_summary=str(exc),
+            provider=normalized_provider,
+            resolved_model=model,
+            fallback_used=False,
+            plugin_flags=plugin_flags_from_plugins([{"id": "response-healing"}] if normalized_provider == PROVIDER_OPENROUTER else []),
         )
         raise
 
@@ -132,6 +137,10 @@ def request_self_healing_analysis_with_openai(
         has_files=False,
         has_images=False,
         status="success",
+        provider=normalized_provider,
+        resolved_model=model,
+        fallback_used=False,
+        plugin_flags=plugin_flags_from_plugins([{"id": "response-healing"}] if normalized_provider == PROVIDER_OPENROUTER else []),
     )
     return payload
 

--- a/services/usage_logging.py
+++ b/services/usage_logging.py
@@ -22,7 +22,17 @@ _SAFE_MODEL_LOG_VALUES = {
     "gpt-4o-mini-tts": "gpt-4o-mini-tts",
     "gpt-5.4-mini": "gpt-5.4-mini",
     "openai/gpt-4o-mini": "openai/gpt-4o-mini",
+    "openai/gpt-4o": "openai/gpt-4o",
     "openai/gpt-audio-mini": "openai/gpt-audio-mini",
+}
+_SAFE_PROVIDER_LOG_VALUES = {"openrouter", "openai"}
+_SAFE_ROUTING_PROFILE_LOG_VALUES = {
+    "conversion_strict",
+    "refinement_strict",
+    "captioning_vision",
+    "general_chat_economy",
+    "research_tooling",
+    "transcription_audio",
 }
 _SAFE_FEATURE_LOG_VALUES = {
     "contractor_conversion",
@@ -71,7 +81,30 @@ def sanitize_error_summary(error_summary: str) -> str:
 def sanitize_model_for_logging(model: str) -> str:
     """Return a fixed safe label for the configured model."""
     value = str(model or "").strip()
-    return _SAFE_MODEL_LOG_VALUES.get(value, "[CONFIGURED_MODEL]")
+    if value in _SAFE_MODEL_LOG_VALUES:
+        return value
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,95}", value):
+        return value
+    return "[CONFIGURED_MODEL]"
+
+
+def sanitize_provider_for_logging(provider: str) -> str:
+    value = str(provider or "").strip().lower()
+    return value if value in _SAFE_PROVIDER_LOG_VALUES else ""
+
+
+def sanitize_routing_profile_for_logging(routing_profile: str) -> str:
+    value = str(routing_profile or "").strip()
+    return value if value in _SAFE_ROUTING_PROFILE_LOG_VALUES else ""
+
+
+def sanitize_plugin_flags_for_logging(plugin_flags: dict[str, object] | None) -> dict[str, bool]:
+    flags = plugin_flags if isinstance(plugin_flags, dict) else {}
+    return {
+        "web": bool(flags.get("web", False)),
+        "file_parser": bool(flags.get("file_parser", False)),
+        "response_healing": bool(flags.get("response_healing", False)),
+    }
 
 
 def sanitize_feature_name_for_logging(feature_name: str) -> str:
@@ -94,6 +127,11 @@ def log_usage_event(
     has_images: bool,
     status: str,
     error_summary: str = "",
+    provider: str = "",
+    routing_profile: str = "",
+    resolved_model: str = "",
+    fallback_used: bool = False,
+    plugin_flags: dict[str, object] | None = None,
 ) -> None:
     """Append one AI usage event to the local JSONL log."""
     try:
@@ -102,6 +140,11 @@ def log_usage_event(
             "timestamp": utc_timestamp(),
             "feature_name": sanitize_feature_name_for_logging(feature_name),
             "model": sanitize_model_for_logging(model),
+            "provider": sanitize_provider_for_logging(provider),
+            "routing_profile": sanitize_routing_profile_for_logging(routing_profile),
+            "resolved_model": sanitize_model_for_logging(resolved_model or model),
+            "fallback_used": bool(fallback_used),
+            "plugin_flags": sanitize_plugin_flags_for_logging(plugin_flags),
             "has_files": bool(has_files),
             "has_images": bool(has_images),
             # Keep failure tracking high-level; never persist raw or derived error text locally.

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,73 @@
+from services.model_routing import (
+    PROFILE_CAPTIONING_VISION,
+    PROFILE_CONVERSION_STRICT,
+    PROVIDER_OPENROUTER,
+    is_transient_ai_error,
+    model_attempts,
+    openrouter_plugins_for_route,
+    plugin_flags_from_plugins,
+    resolve_routing_profile,
+)
+
+
+def test_routing_profile_resolution_uses_provider_defaults_and_env_override(monkeypatch):
+    route = resolve_routing_profile(PROFILE_CONVERSION_STRICT, provider=PROVIDER_OPENROUTER)
+
+    assert route.primary_model == "openai/gpt-4o-mini"
+    assert route.fallback_model == "openai/gpt-4o"
+    assert route.structured_output_required is True
+    assert route.file_parser_allowed is True
+    assert route.response_healing_allowed is True
+
+    monkeypatch.setenv("OPENROUTER_CONVERSION_STRICT_PRIMARY_MODEL", "vendor/custom-model")
+    overridden = resolve_routing_profile(
+        PROFILE_CONVERSION_STRICT,
+        provider=PROVIDER_OPENROUTER,
+        primary_model_override="ui/session-model",
+    )
+
+    assert overridden.primary_model == "vendor/custom-model"
+    assert model_attempts(overridden) == [
+        ("vendor/custom-model", False),
+        ("openai/gpt-4o", True),
+    ]
+
+
+def test_openrouter_plugin_policy_is_driven_by_profile_capabilities():
+    route = resolve_routing_profile(
+        PROFILE_CONVERSION_STRICT,
+        provider=PROVIDER_OPENROUTER,
+        allow_web_research=True,
+        allow_file_parser=True,
+    )
+
+    plugins = openrouter_plugins_for_route(
+        route,
+        include_web=True,
+        include_file_parser=True,
+        include_response_healing=True,
+    )
+
+    assert {"id": "web"} in plugins
+    assert {"id": "response-healing"} in plugins
+    assert plugin_flags_from_plugins(plugins) == {
+        "web": True,
+        "file_parser": True,
+        "response_healing": True,
+    }
+
+    caption_route = resolve_routing_profile(PROFILE_CAPTIONING_VISION, provider=PROVIDER_OPENROUTER)
+    caption_plugins = openrouter_plugins_for_route(caption_route, include_web=True, include_file_parser=True)
+    assert plugin_flags_from_plugins(caption_plugins) == {
+        "web": False,
+        "file_parser": False,
+        "response_healing": False,
+    }
+
+
+def test_transient_error_detection_for_provider_fallbacks():
+    transient = RuntimeError("Provider returned error: model unavailable")
+    assert is_transient_ai_error(transient) is True
+
+    schema_error = ValueError("Structured report payload must be a report object or list of reports.")
+    assert is_transient_ai_error(schema_error) is False

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -63,6 +63,59 @@ def test_openrouter_structured_conversion_uses_chat_completions(monkeypatch):
     assert {"id": "response-healing"} in captured["extra_body"]["plugins"]
 
 
+def test_openrouter_conversion_retries_once_on_transient_model_failure(monkeypatch):
+    calls = []
+    events = []
+    report = {header: "" for header in converter_service.REPORT_HEADERS}
+    report.update({"Date": "2026-04-21", "Site_Name": "Site A", "Work_Executed": "Crew completed trenching."})
+
+    class _TransientModelError(RuntimeError):
+        status_code = 503
+
+    class _FakeCompletions:
+        def create(self, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise _TransientModelError("model unavailable")
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(
+                            content='{"reports": [' + str(report).replace("'", '"') + "]}"
+                        )
+                    )
+                ]
+            )
+
+    class _FakeChat:
+        def __init__(self):
+            self.completions = _FakeCompletions()
+
+    class _FakeClient:
+        def __init__(self, **_kwargs):
+            self.chat = _FakeChat()
+
+    monkeypatch.setitem(sys.modules, "openai", types.SimpleNamespace(OpenAI=_FakeClient))
+    monkeypatch.setattr(converter_service, "log_usage_event", lambda **kwargs: events.append(kwargs))
+
+    rows, sources = converter_service.request_structured_reports_with_openai(
+        "Raw contractor text",
+        api_key="openrouter-key",
+        model="",
+        discipline="Civil",
+        provider="openrouter",
+    )
+
+    assert rows == [report]
+    assert sources == []
+    assert [call["model"] for call in calls] == ["openai/gpt-4o-mini", "openai/gpt-4o"]
+    assert events[0]["status"] == "failed"
+    assert events[0]["fallback_used"] is False
+    assert events[1]["status"] == "success"
+    assert events[1]["fallback_used"] is True
+    assert events[1]["routing_profile"] == "conversion_strict"
+
+
 def test_openrouter_transcription_sends_input_audio(monkeypatch):
     captured = {}
 

--- a/tests/test_usage_logging_service.py
+++ b/tests/test_usage_logging_service.py
@@ -111,6 +111,35 @@ def test_log_usage_event_keeps_known_safe_model_identifiers(tmp_path, monkeypatc
     assert payload["model"] == "gpt-5.4-mini"
 
 
+def test_log_usage_event_records_safe_provider_routing_and_plugin_metadata(tmp_path, monkeypatch):
+    log_path = tmp_path / "usage.jsonl"
+    monkeypatch.setattr(usage_logging, "USAGE_LOG_FILE", log_path)
+
+    usage_logging.log_usage_event(
+        feature_name="contractor_conversion",
+        model="openai/gpt-4o-mini",
+        has_files=True,
+        has_images=True,
+        status="success",
+        provider="openrouter",
+        routing_profile="conversion_strict",
+        resolved_model="openai/gpt-4o",
+        fallback_used=True,
+        plugin_flags={"web": True, "file_parser": False, "response_healing": True},
+    )
+
+    payload = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert payload["provider"] == "openrouter"
+    assert payload["routing_profile"] == "conversion_strict"
+    assert payload["resolved_model"] == "openai/gpt-4o"
+    assert payload["fallback_used"] is True
+    assert payload["plugin_flags"] == {
+        "web": True,
+        "file_parser": False,
+        "response_healing": True,
+    }
+
+
 def test_log_usage_event_uses_allowlisted_feature_and_status(tmp_path, monkeypatch):
     log_path = tmp_path / "usage.jsonl"
     monkeypatch.setattr(usage_logging, "USAGE_LOG_FILE", log_path)


### PR DESCRIPTION
## Summary
- Adds a central `services/model_routing.py` routing profile layer for OpenRouter/OpenAI model selection, fallback models, task budgets, structured-output requirements, and OpenRouter plugin policy.
- Refactors existing OpenRouter call paths in `openai_client`, `converter_service`, `media_service`, and `research_service` to consume routing profiles instead of embedding task policy locally.
- Adds one-retry fallback behavior for contractor conversion, contractor refinement, and image captioning when transient provider/model availability failures occur.

## Existing modules preserved and reused
- Preserves current Streamlit workflows and UI structure.
- Preserves OpenAI support, including OpenAI-only Responses tools and OpenAI-only TTS behavior.
- Does not change `report.py`, `report_structuring.py`, `sheets.py`, `config.py`, or Google Sheets/report-generation behavior.

## Routing profiles added
- `conversion_strict`
- `refinement_strict`
- `captioning_vision`
- `general_chat_economy`
- `research_tooling`
- `transcription_audio`

## Fallback behavior
- Fallback retries are single-attempt only.
- Fallback is limited to transient provider/model availability failures.
- Schema/validation/content errors are not retried indefinitely.
- Usage logs record whether fallback was used.

## Usage logging and observability
- Adds non-sensitive metadata for provider, routing profile, resolved model, fallback usage, and plugin flags.
- Continues to avoid logging secrets, raw user content, or request payloads.

## Documentation
- README now explains routing profiles as the control point for future model changes.
- Documents profile-specific model override environment variables such as `OPENROUTER_CONVERSION_STRICT_PRIMARY_MODEL` and `OPENROUTER_CONVERSION_STRICT_FALLBACK_MODEL`.

## Testing
- `pytest -q` -> 89 passed

## Risks / follow-up work
- OpenRouter model availability can still change by provider; routing-profile environment overrides are the intended low-risk control point for future changes.
- TTS remains OpenAI-only by design until a supported OpenRouter-compatible TTS path is selected.