### PR TITLE
Allow clipboard image paste uploads for site photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Streamlit app is organized into four workspaces:
 1. **Reporting Workspace**
    - discipline, site, and date filters
    - review and edit rows from Google Sheets
-   - attach site photos by site/date pair
+   - attach or paste site photos by site/date pair
    - generate final ZIP exports with the canonical report engine
 
 2. **Contractor Conversion**

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ uvicorn[standard]
 pydantic
 pytest
 httpx
+pyarrow

--- a/streamlit_ui/clipboard_image_paste.py
+++ b/streamlit_ui/clipboard_image_paste.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from pathlib import Path
+
+import streamlit as st
+import streamlit.components.v1 as components
+
+MAX_CLIPBOARD_IMAGE_BYTES = 20 * 1024 * 1024
+_COMPONENT_DIR = Path(__file__).parent / "components" / "clipboard_image_paste"
+_clipboard_image_paste = components.declare_component(
+    "clipboard_image_paste",
+    path=str(_COMPONENT_DIR),
+)
+
+
+def _has_streamlit_runtime() -> bool:
+    """Return whether custom components can run in the active Streamlit runtime."""
+    try:
+        from streamlit.runtime.scriptrunner_utils.script_run_context import get_script_run_ctx
+
+        return get_script_run_ctx() is not None
+    except Exception:
+        return False
+
+
+def clipboard_seen_paste_ids() -> dict[str, list[str]]:
+    return st.session_state.setdefault("_clipboard_image_paste_seen_ids", {})
+
+
+def image_bytes_from_data_url(data_url: str, *, max_bytes: int = MAX_CLIPBOARD_IMAGE_BYTES) -> bytes:
+    """Decode one clipboard image data URL into bytes."""
+    value = str(data_url or "").strip()
+    if not value.startswith("data:image/") or ";base64," not in value:
+        raise ValueError("Clipboard image must be a base64 image data URL.")
+
+    _, encoded = value.split(";base64,", 1)
+    try:
+        image_bytes = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Clipboard image data is not valid base64.") from exc
+
+    if not image_bytes:
+        raise ValueError("Clipboard image is empty.")
+    if len(image_bytes) > max_bytes:
+        raise ValueError("Clipboard image is too large.")
+    return image_bytes
+
+
+def pasted_image_bytes_from_component_value(
+    value: object,
+    *,
+    key: str,
+) -> list[bytes]:
+    """Return newly pasted image bytes from a clipboard component value."""
+    if not isinstance(value, dict):
+        return []
+
+    paste_id = str(value.get("paste_id", "") or "").strip()
+    if not paste_id:
+        return []
+
+    seen_by_key = clipboard_seen_paste_ids()
+    seen = list(seen_by_key.setdefault(key, []))
+    if paste_id in seen:
+        return []
+
+    images = value.get("images", [])
+    if not isinstance(images, list):
+        return []
+
+    decoded_images: list[bytes] = []
+    for item in images:
+        if not isinstance(item, dict):
+            continue
+        mime_type = str(item.get("mime_type", "") or "").strip()
+        if mime_type and not mime_type.startswith("image/"):
+            continue
+        try:
+            decoded_images.append(image_bytes_from_data_url(str(item.get("data_url", "") or "")))
+        except ValueError:
+            continue
+
+    seen.append(paste_id)
+    seen_by_key[key] = seen[-100:]
+    st.session_state["_clipboard_image_paste_seen_ids"] = seen_by_key
+    return decoded_images
+
+
+def render_clipboard_image_paste(
+    *,
+    label: str,
+    key: str,
+    max_images: int = 8,
+) -> list[bytes]:
+    """Render a paste target and return newly pasted image bytes."""
+    if not _has_streamlit_runtime():
+        return []
+
+    try:
+        value = _clipboard_image_paste(
+            label=label,
+            max_images=max(1, int(max_images)),
+            default={},
+            key=key,
+        )
+    except Exception:
+        # The normal uploader remains the reliable fallback if components are unavailable.
+        return []
+    return pasted_image_bytes_from_component_value(value, key=key)

--- a/streamlit_ui/components/clipboard_image_paste/index.html
+++ b/streamlit_ui/components/clipboard_image_paste/index.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: transparent;
+      }
+
+      .paste-zone {
+        border: 1px dashed #9ca3af;
+        border-radius: 8px;
+        background: #f8fafc;
+        color: #334155;
+        cursor: text;
+        min-height: 82px;
+        padding: 14px 16px;
+        outline: none;
+        transition: border-color 0.15s ease, background-color 0.15s ease;
+      }
+
+      .paste-zone:focus {
+        border-color: #2563eb;
+        background: #eff6ff;
+      }
+
+      .label {
+        display: block;
+        font-size: 0.9rem;
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+
+      .hint,
+      .status {
+        display: block;
+        font-size: 0.78rem;
+        line-height: 1.35;
+      }
+
+      .hint {
+        color: #64748b;
+      }
+
+      .status {
+        color: #166534;
+        margin-top: 8px;
+      }
+
+      .status.error {
+        color: #991b1b;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="paste-zone" class="paste-zone" tabindex="0" role="button" aria-label="Paste clipboard images here">
+      <span id="label" class="label">Paste images from clipboard</span>
+      <span class="hint">Click here, then press Ctrl+V. Screenshots and copied photos will be attached to this site/date group.</span>
+      <span id="status" class="status"></span>
+    </div>
+
+    <script>
+      const COMPONENT_READY = "streamlit:componentReady";
+      const SET_COMPONENT_VALUE = "streamlit:setComponentValue";
+      const SET_FRAME_HEIGHT = "streamlit:setFrameHeight";
+      const RENDER = "streamlit:render";
+
+      const zone = document.getElementById("paste-zone");
+      const label = document.getElementById("label");
+      const statusEl = document.getElementById("status");
+      let maxImages = 8;
+
+      function send(type, payload = {}) {
+        window.parent.postMessage({ isStreamlitMessage: true, type, ...payload }, "*");
+      }
+
+      function setFrameHeight() {
+        send(SET_FRAME_HEIGHT, { height: document.documentElement.scrollHeight });
+      }
+
+      function setStatus(message, isError = false) {
+        statusEl.textContent = message;
+        statusEl.className = isError ? "status error" : "status";
+        setFrameHeight();
+      }
+
+      function readFileAsDataUrl(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result || ""));
+          reader.onerror = () => reject(new Error("Unable to read pasted image."));
+          reader.readAsDataURL(file);
+        });
+      }
+
+      async function handlePaste(event) {
+        const items = Array.from(event.clipboardData?.items || []);
+        const imageItems = items.filter((item) => String(item.type || "").startsWith("image/"));
+        if (!imageItems.length) {
+          setStatus("Clipboard does not contain an image.", true);
+          return;
+        }
+
+        event.preventDefault();
+        const files = imageItems
+          .map((item) => item.getAsFile())
+          .filter((file) => file && String(file.type || "").startsWith("image/"))
+          .slice(0, maxImages);
+
+        if (!files.length) {
+          setStatus("No readable image was found on the clipboard.", true);
+          return;
+        }
+
+        try {
+          const images = [];
+          for (const file of files) {
+            images.push({
+              name: file.name || `clipboard-${Date.now()}.png`,
+              mime_type: file.type || "image/png",
+              data_url: await readFileAsDataUrl(file),
+              size: file.size || 0,
+            });
+          }
+          const pasteId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          send(SET_COMPONENT_VALUE, {
+            value: {
+              paste_id: pasteId,
+              images,
+            },
+            dataType: "json",
+          });
+          setStatus(`${images.length} pasted image${images.length === 1 ? "" : "s"} added.`);
+        } catch (error) {
+          setStatus(error?.message || "Unable to process pasted image.", true);
+        }
+      }
+
+      zone.addEventListener("paste", handlePaste);
+      zone.addEventListener("click", () => zone.focus());
+
+      window.addEventListener("message", (event) => {
+        const data = event.data || {};
+        if (data.type !== RENDER) {
+          return;
+        }
+        const args = data.args || {};
+        label.textContent = args.label || "Paste images from clipboard";
+        maxImages = Number(args.max_images || 8);
+        setFrameHeight();
+      });
+
+      send(COMPONENT_READY, { apiVersion: 1 });
+      setFrameHeight();
+    </script>
+  </body>
+</html>

--- a/streamlit_ui/reporting_workspace.py
+++ b/streamlit_ui/reporting_workspace.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+
 import pandas as pd
 import streamlit as st
 
@@ -10,6 +12,7 @@ from services.converter_service import normalize_structured_rows
 from services.media_service import generate_ai_photo_captions_for_reports
 from services.openai_client import active_ai_provider, default_ai_model, load_ai_api_key, openai_sdk_ready, provider_label
 from sheets import CACHE_FILE, append_rows_to_sheet, get_sheet_data, get_unique_sites_and_dates, load_offline_cache
+from streamlit_ui.clipboard_image_paste import render_clipboard_image_paste
 from streamlit_ui.helpers import (
     safe_button,
     safe_caption,
@@ -173,6 +176,85 @@ def photo_group_display_label(site: str, date: str, image_group: list[bytes], ca
     if image_group:
         return f"{label} - Photos attached"
     return f"{label} - No photos"
+
+
+def append_images_to_group(normalized_key: tuple[str, str], images: list[bytes]) -> list[bytes]:
+    """Append images to the current site/date group and return the group."""
+    if not images:
+        return (st.session_state.get("images", {}) or {}).get(normalized_key, [])
+    image_store = st.session_state.setdefault("images", {})
+    current_group = list(image_store.get(normalized_key, []) or [])
+    current_group.extend(bytes(image) for image in images if image)
+    image_store[normalized_key] = current_group
+    st.session_state["images"] = image_store
+    return current_group
+
+
+def uploaded_file_bytes(uploaded_file: object) -> bytes:
+    """Read one uploaded file without permanently advancing its stream when possible."""
+    getvalue_fn = getattr(uploaded_file, "getvalue", None)
+    if callable(getvalue_fn):
+        return bytes(getvalue_fn() or b"")
+
+    read_fn = getattr(uploaded_file, "read", None)
+    if not callable(read_fn):
+        return b""
+
+    tell_fn = getattr(uploaded_file, "tell", None)
+    seek_fn = getattr(uploaded_file, "seek", None)
+    position = None
+    if callable(tell_fn):
+        try:
+            position = tell_fn()
+        except Exception:
+            position = None
+
+    data = bytes(read_fn() or b"")
+    if callable(seek_fn) and position is not None:
+        try:
+            seek_fn(position)
+        except Exception:
+            pass
+    return data
+
+
+def uploaded_image_signature(files: list[object]) -> str:
+    """Return a stable signature for uploaded image files."""
+    digest = hashlib.sha256()
+    for uploaded_file in files or []:
+        name = str(getattr(uploaded_file, "name", "") or "").strip()
+        data = uploaded_file_bytes(uploaded_file)
+        digest.update(name.encode("utf-8"))
+        digest.update(len(data).to_bytes(8, "big", signed=False))
+        digest.update(hashlib.sha256(data).digest())
+    return digest.hexdigest()
+
+
+def append_new_uploaded_images(
+    normalized_key: tuple[str, str],
+    files: list[object],
+    *,
+    upload_key: str,
+) -> list[bytes]:
+    """Append uploaded images once per uploader change."""
+    if not files:
+        return (st.session_state.get("images", {}) or {}).get(normalized_key, [])
+
+    signature = uploaded_image_signature(files)
+    signature_store = st.session_state.setdefault("_image_upload_signatures", {})
+    current_group = (st.session_state.get("images", {}) or {}).get(normalized_key, [])
+    if signature_store.get(upload_key) == signature and current_group:
+        return current_group
+
+    image_bytes: list[bytes] = []
+    for uploaded_file in files:
+        data = uploaded_file_bytes(uploaded_file)
+        if data:
+            image_bytes.append(data)
+
+    signature_store[upload_key] = signature
+    st.session_state["_image_upload_signatures"] = signature_store
+    return append_images_to_group(normalized_key, image_bytes)
 
 
 def render_output_settings_panel() -> dict[str, object]:
@@ -400,15 +482,22 @@ def render_reporting_workspace(
                 expanded=False,
             ):
                 render_status_badges(photo_group_statuses(image_group, captions))
+                uploader_key = f"uploader_{site}_{date}"
                 files = safe_file_uploader(
                     f"Upload images for {site} - {date}",
                     accept_multiple_files=True,
                     type=["png", "jpg", "jpeg", "webp"],
-                    key=f"uploader_{site}_{date}",
+                    key=uploader_key,
                 )
                 if files:
-                    st.session_state.setdefault("images", {})[normalized_key] = [f.read() for f in files]
-                    image_group = st.session_state["images"][normalized_key]
+                    image_group = append_new_uploaded_images(normalized_key, list(files), upload_key=uploader_key)
+                pasted_images = render_clipboard_image_paste(
+                    label=f"Paste copied images for {site} - {date}",
+                    key=f"clipboard_paste_{site}_{date}",
+                )
+                if pasted_images:
+                    image_group = append_images_to_group(normalized_key, pasted_images)
+                    st.success(f"Added {len(pasted_images)} pasted image(s) to {site} - {date}.")
                 if image_group:
                     safe_image(image_group, width=220)
                 if captions:

--- a/tests/test_clipboard_image_paste.py
+++ b/tests/test_clipboard_image_paste.py
@@ -1,0 +1,40 @@
+import base64
+import types
+
+import pytest
+
+from streamlit_ui import clipboard_image_paste
+
+
+def test_image_bytes_from_data_url_decodes_base64_image():
+    data_url = "data:image/png;base64," + base64.b64encode(b"png-bytes").decode("ascii")
+
+    assert clipboard_image_paste.image_bytes_from_data_url(data_url) == b"png-bytes"
+
+
+def test_image_bytes_from_data_url_rejects_non_image_payload():
+    data_url = "data:text/plain;base64," + base64.b64encode(b"text").decode("ascii")
+
+    with pytest.raises(ValueError):
+        clipboard_image_paste.image_bytes_from_data_url(data_url)
+
+
+def test_pasted_image_bytes_from_component_value_consumes_each_paste_once(monkeypatch):
+    st_stub = types.SimpleNamespace(session_state={})
+    monkeypatch.setattr(clipboard_image_paste, "st", st_stub)
+    data_url = "data:image/jpeg;base64," + base64.b64encode(b"image-bytes").decode("ascii")
+    value = {
+        "paste_id": "paste-1",
+        "images": [
+            {
+                "mime_type": "image/jpeg",
+                "data_url": data_url,
+            }
+        ],
+    }
+
+    first = clipboard_image_paste.pasted_image_bytes_from_component_value(value, key="site-a")
+    second = clipboard_image_paste.pasted_image_bytes_from_component_value(value, key="site-a")
+
+    assert first == [b"image-bytes"]
+    assert second == []

--- a/tests/test_reporting_workspace.py
+++ b/tests/test_reporting_workspace.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import types
 
 from streamlit_ui import helpers
 from streamlit_ui import reporting_workspace
@@ -97,6 +98,15 @@ class _StreamlitStub:
         return None
 
 
+class _UploadedImageStub:
+    def __init__(self, name: str, data: bytes):
+        self.name = name
+        self._data = data
+
+    def getvalue(self):
+        return self._data
+
+
 def _patch_layout(monkeypatch):
     monkeypatch.setattr(helpers, "st", reporting_workspace.st)
     monkeypatch.setattr(reporting_workspace, "render_workspace_topbar", lambda *_, **__: None)
@@ -106,6 +116,7 @@ def _patch_layout(monkeypatch):
     monkeypatch.setattr(reporting_workspace, "render_note", lambda *_, **__: None)
     monkeypatch.setattr(reporting_workspace, "render_status_badges", lambda *_, **__: None)
     monkeypatch.setattr(reporting_workspace, "safe_image", lambda *_, **__: None)
+    monkeypatch.setattr(reporting_workspace, "render_clipboard_image_paste", lambda **_kwargs: [])
 
 
 def test_render_reporting_workspace_uses_empty_filter_defaults_and_preserves_all_scope(monkeypatch):
@@ -183,3 +194,17 @@ def test_render_reporting_workspace_caption_failure_uses_fallback_and_generates_
     assert captured_kwargs["image_caption_mapping"] == {("Site A", "2026-04-18"): ["", ""]}
     assert any("captions failed and were skipped" in message for message in st_stub.warning_messages)
     assert any(issue[0] == "photo_captioning" for issue in recorded_issues)
+
+
+def test_append_new_uploaded_images_does_not_duplicate_same_uploader_payload(monkeypatch):
+    st_stub = types.SimpleNamespace(session_state={})
+    monkeypatch.setattr(reporting_workspace, "st", st_stub)
+    files = [_UploadedImageStub("site.jpg", b"image-bytes")]
+
+    first = reporting_workspace.append_new_uploaded_images(("Site A", "2026-04-18"), files, upload_key="uploader")
+    second = reporting_workspace.append_new_uploaded_images(("Site A", "2026-04-18"), files, upload_key="uploader")
+    appended = reporting_workspace.append_images_to_group(("Site A", "2026-04-18"), [b"pasted-image"])
+
+    assert first == [b"image-bytes"]
+    assert second == [b"image-bytes"]
+    assert appended == [b"image-bytes", b"pasted-image"]


### PR DESCRIPTION
## Summary
- Adds a Streamlit custom component that accepts pasted clipboard images for site/date photo groups.
- Appends pasted images into the existing report photo workflow without replacing the normal file uploader.
- Deduplicates uploader and paste events so reruns do not duplicate the same images.
- Documents pasted photo support and adds targeted tests.

## Validation
- `pytest -q` passed: 93 tests.
- `git diff --check HEAD` passed.

## Notes
- The previous OpenRouter routing PR for this branch was already merged, so this opens a new PR for the additional clipboard upload commit.