### PR TITLE
Improve Google Sheets permission diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ GOOGLE_CREDENTIALS = """
 
 The legacy `gcp_service_account` secret is still accepted for backward compatibility.
 
+Share the configured Google Sheet with the service account `client_email` as an
+Editor. The app uses `SHEET_ID` and `SHEET_NAME` from `config.py` or environment
+overrides; if the wrong spreadsheet ID is configured, or if the tab/range is
+protected, append operations will fail with a Google Sheets permission error.
+
 ## Trust Controls In Contractor Conversion
 
 The contractor workflow includes stronger controls than the earlier implementation:

--- a/sheets.py
+++ b/sheets.py
@@ -5,10 +5,15 @@ from typing import Dict, List
 import streamlit as st
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 from config import CACHE_FILE, SHEET_ID, SHEET_NAME
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+
+
+class GoogleSheetAccessError(RuntimeError):
+    """Actionable Google Sheets access/configuration failure."""
 
 
 def _load_service_account_info() -> Dict:
@@ -36,6 +41,48 @@ def get_service_account_credentials() -> service_account.Credentials:
     )
 
 
+def get_configured_service_account_email() -> str:
+    """Return the configured service account email when available."""
+
+    try:
+        service_account_info = _load_service_account_info()
+    except Exception:
+        return ""
+    return str(service_account_info.get("client_email", "")).strip()
+
+
+def _spreadsheet_url() -> str:
+    return f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/edit"
+
+
+def _http_error_status(exc: HttpError) -> int | None:
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    try:
+        return int(status)
+    except (TypeError, ValueError):
+        return None
+
+
+def _raise_actionable_sheet_error(operation: str, exc: HttpError):
+    status = _http_error_status(exc)
+    if status not in {401, 403}:
+        raise exc
+
+    service_account_email = get_configured_service_account_email()
+    share_target = (
+        f"Share the spreadsheet with `{service_account_email}` as Editor."
+        if service_account_email
+        else "The service account email could not be read from Streamlit secrets."
+    )
+    raise GoogleSheetAccessError(
+        "Google Sheets permission denied while "
+        f"{operation}. {share_target} Configured spreadsheet: {_spreadsheet_url()} "
+        f"Configured tab: `{SHEET_NAME}`. If the tab or range is protected, allow this "
+        "service account to edit it. Original Google API status: "
+        f"{status}."
+    ) from exc
+
+
 def _build_service():
     creds = get_service_account_credentials()
     return build("sheets", "v4", credentials=creds)
@@ -46,10 +93,13 @@ def get_sheet_data() -> List[List[str]]:
     """Fetch rows from the configured Google Sheet."""
     service = _build_service()
     sheet = service.spreadsheets()
-    result = sheet.values().get(
-        spreadsheetId=SHEET_ID,
-        range=f"{SHEET_NAME}!A:N",
-    ).execute()
+    try:
+        result = sheet.values().get(
+            spreadsheetId=SHEET_ID,
+            range=f"{SHEET_NAME}!A:N",
+        ).execute()
+    except HttpError as exc:
+        _raise_actionable_sheet_error("reading rows", exc)
     rows = result.get("values", [])
     expected_cols = 14
     padded_rows = [row + [""] * max(0, expected_cols - len(row)) for row in rows]
@@ -61,12 +111,15 @@ def append_rows_to_sheet(rows: List[List[str]]):
         return
     service = _build_service()
     body = {"values": rows}
-    service.spreadsheets().values().append(
-        spreadsheetId=SHEET_ID,
-        range=SHEET_NAME,
-        valueInputOption="USER_ENTERED",
-        body=body,
-    ).execute()
+    try:
+        service.spreadsheets().values().append(
+            spreadsheetId=SHEET_ID,
+            range=SHEET_NAME,
+            valueInputOption="USER_ENTERED",
+            body=body,
+        ).execute()
+    except HttpError as exc:
+        _raise_actionable_sheet_error("appending rows", exc)
 
 
 def load_offline_cache() -> Dict:

--- a/tests/test_sheets_module.py
+++ b/tests/test_sheets_module.py
@@ -1,6 +1,23 @@
 from pathlib import Path
 
+import pytest
+from googleapiclient.errors import HttpError
+
 import sheets
+
+
+class _FakeHttpResponse(dict):
+    def __init__(self, status: int):
+        super().__init__()
+        self.status = status
+        self.reason = "Forbidden"
+
+
+def _http_error(status: int) -> HttpError:
+    return HttpError(
+        _FakeHttpResponse(status),
+        b'{"error": {"message": "The caller does not have permission"}}',
+    )
 
 
 def test_get_unique_sites_and_dates():
@@ -22,3 +39,32 @@ def test_save_and_load_offline_cache(tmp_path, monkeypatch):
     data = sheets.load_offline_cache()
     assert data["rows"] == rows
     assert data["uploads"] == {"Site A|2024-01-01": []}
+
+
+def test_permission_error_includes_service_account_and_sheet_context(monkeypatch):
+    monkeypatch.setattr(
+        sheets,
+        "_load_service_account_info",
+        lambda: {"client_email": "reports-writer@example.iam.gserviceaccount.com"},
+    )
+    monkeypatch.setattr(sheets, "SHEET_ID", "sheet-123")
+    monkeypatch.setattr(sheets, "SHEET_NAME", "Reports")
+
+    with pytest.raises(sheets.GoogleSheetAccessError) as exc_info:
+        sheets._raise_actionable_sheet_error("appending rows", _http_error(403))
+
+    message = str(exc_info.value)
+    assert "reports-writer@example.iam.gserviceaccount.com" in message
+    assert "as Editor" in message
+    assert "sheet-123" in message
+    assert "`Reports`" in message
+    assert "Original Google API status: 403" in message
+
+
+def test_non_permission_google_api_error_is_not_rewritten():
+    original = _http_error(500)
+
+    with pytest.raises(HttpError) as exc_info:
+        sheets._raise_actionable_sheet_error("reading rows", original)
+
+    assert exc_info.value is original


### PR DESCRIPTION
## Summary
- Replaces raw Google Sheets 401/403 API tracebacks with an actionable permission message.
- Includes the configured spreadsheet URL, sheet tab, and service-account email to share as Editor when available.
- Documents the required Google Sheet sharing setup in the README.
- Adds focused tests for permission error formatting and non-permission error passthrough.

## Why
The append workflow can authenticate successfully but still fail with `The caller does not have permission` when the Google Sheet is not shared with the configured service account or the target tab/range is protected. The app now explains the operational fix directly.

## Validation
- `pytest tests\\test_sheets_module.py -q` passed.
- `pytest -q` passed: 95 tests.
- `git diff --check` passed with only existing CRLF normalization warnings.